### PR TITLE
Remove lots of noise from function signatures

### DIFF
--- a/src/affine.rs
+++ b/src/affine.rs
@@ -11,7 +11,8 @@ use traits::{
 };
 
 use utils::{
-    cast
+    cast,
+    VecBuffer
 };
 
 use conv::{
@@ -26,8 +27,7 @@ pub fn rotate_nearest<I>(
     image: &I,
     center: (f32, f32),
     theta: f32,
-    default: I::Pixel)
-        -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    default: I::Pixel) -> VecBuffer<I::Pixel>
     where I: GenericImage + 'static,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -77,8 +77,7 @@ pub fn rotate_bilinear<I>(
     image: &I,
     center: (f32, f32),
     theta: f32,
-    default: I::Pixel)
-        -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    default: I::Pixel) -> VecBuffer<I::Pixel>
     where I: GenericImage + 'static,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<f32> + Clamp<f32> + 'static {
@@ -148,8 +147,7 @@ pub fn rotate_bilinear<I>(
 /// Translates the input image by t. Note that image coordinates increase from
 /// top left to bottom right. Output pixels whose pre-image are not in the input
 /// image are set to the boundary pixel in the input image nearest to their pre-image.
-pub fn translate<I>(image: &I, t: (i32, i32))
-        -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+pub fn translate<I>(image: &I, t: (i32, i32)) -> VecBuffer<I::Pixel>
     where I: GenericImage + 'static,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -28,9 +28,7 @@ pub fn rotate_nearest<I>(
     center: (f32, f32),
     theta: f32,
     default: I::Pixel) -> VecBuffer<I::Pixel>
-    where I: GenericImage + 'static,
-          I::Pixel: 'static,
-          <I::Pixel as Pixel>::Subpixel: 'static {
+    where I: GenericImage, I::Pixel: 'static {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
@@ -78,9 +76,9 @@ pub fn rotate_bilinear<I>(
     center: (f32, f32),
     theta: f32,
     default: I::Pixel) -> VecBuffer<I::Pixel>
-    where I: GenericImage + 'static,
+    where I: GenericImage,
           I::Pixel: 'static,
-          <I::Pixel as Pixel>::Subpixel: ValueInto<f32> + Clamp<f32> + 'static {
+          <I::Pixel as Pixel>::Subpixel: ValueInto<f32> + Clamp<f32> {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
@@ -148,9 +146,7 @@ pub fn rotate_bilinear<I>(
 /// top left to bottom right. Output pixels whose pre-image are not in the input
 /// image are set to the boundary pixel in the input image nearest to their pre-image.
 pub fn translate<I>(image: &I, t: (i32, i32)) -> VecBuffer<I::Pixel>
-    where I: GenericImage + 'static,
-          I::Pixel: 'static,
-          <I::Pixel as Pixel>::Subpixel: 'static {
+    where I: GenericImage, I::Pixel: 'static {
 
     use std::cmp;
 

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -10,7 +10,7 @@ use image::{
 /// Returns the cumulative histogram of grayscale values in an 8bpp
 /// grayscale image.
 fn cumulative_histogram<I>(image: &I) -> [i32;256]
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
+    where I: GenericImage<Pixel=Luma<u8>> {
 
     let mut hist = [0i32;256];
 
@@ -28,7 +28,7 @@ fn cumulative_histogram<I>(image: &I) -> [i32;256]
 /// Equalises the histogram of an 8bpp grayscale image in place.
 /// https://en.wikipedia.org/wiki/Histogram_equalization
 pub fn equalize_histogram_mut<I>(image: &mut I)
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
+    where I: GenericImage<Pixel=Luma<u8>> {
 
     let hist = cumulative_histogram(image);
     let total = hist[255] as f32;
@@ -46,7 +46,7 @@ pub fn equalize_histogram_mut<I>(image: &mut I)
 /// Equalises the histogram of an 8bpp grayscale image.
 /// https://en.wikipedia.org/wiki/Histogram_equalization
 pub fn equalize_histogram<I>(image: &I) -> GrayImage
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
+    where I: GenericImage<Pixel=Luma<u8>> {
 
     let mut out: GrayImage = ImageBuffer::new(image.width(), image.height());
     out.copy_from(image, 0, 0);

--- a/src/corners.rs
+++ b/src/corners.rs
@@ -32,7 +32,7 @@ impl Corner {
 /// pixel still qualifies as a corner.
 /// https://en.wikipedia.org/wiki/Features_from_accelerated_segment_test
 pub fn corners_fast12<I>(image: &I, threshold: u8) -> Vec<Corner>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
+    where I: GenericImage<Pixel=Luma<u8>> {
 
     let (width, height) = image.dimensions();
     let mut corners = vec![];
@@ -118,7 +118,7 @@ pub fn suppress_non_maximum(corners: &[Corner], radius: u32)
 /// and a corner pixel is n then the corner will have a score of n - 1.
 fn corner_score_fast12<I>(image: &I, threshold: u8, x: u32, y: u32)
         -> u8
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
+    where I: GenericImage<Pixel=Luma<u8>> {
 
     let mut max = 255u8;
     let mut min = threshold;
@@ -143,7 +143,7 @@ fn corner_score_fast12<I>(image: &I, threshold: u8, x: u32, y: u32)
 /// Checks if the given pixel is a corner.
 fn is_corner_fast12<I>(image: &I, threshold: u8, x: u32, y: u32)
         -> bool
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
+    where I: GenericImage<Pixel=Luma<u8>> {
 
     let (width, height) = image.dimensions();
 

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -6,6 +6,10 @@ use image::{
     ImageBuffer
 };
 
+use utils::{
+    VecBuffer
+};
+
 /// Draws a colored cross on an image in place.
 /// If (x, y) is within the image bounds then as much of the cross
 /// is drawn as will fit. If (x, y) is outside the image bounds then
@@ -39,7 +43,7 @@ pub fn draw_cross_mut<I>(image: &mut I, color: I::Pixel, x: u32, y: u32)
 /// is drawn as will fit. If (x, y) is outside the image bounds then
 /// we draw nothing.
 pub fn draw_cross<I>(image: &I, color: I::Pixel, x: u32, y: u32)
-        -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+        -> VecBuffer<I::Pixel>
     where I: GenericImage + 'static,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -15,9 +15,7 @@ use utils::{
 /// is drawn as will fit. If (x, y) is outside the image bounds then
 /// we draw nothing.
 pub fn draw_cross_mut<I>(image: &mut I, color: I::Pixel, x: u32, y: u32)
-    where I: GenericImage + 'static,
-          I::Pixel: 'static,
-          <I::Pixel as Pixel>::Subpixel: 'static {
+    where I: GenericImage {
 
     let (width, height) = image.dimensions();
     if x >= width || y >= height {
@@ -44,9 +42,7 @@ pub fn draw_cross_mut<I>(image: &mut I, color: I::Pixel, x: u32, y: u32)
 /// we draw nothing.
 pub fn draw_cross<I>(image: &I, color: I::Pixel, x: u32, y: u32)
         -> VecBuffer<I::Pixel>
-    where I: GenericImage + 'static,
-          I::Pixel: 'static,
-          <I::Pixel as Pixel>::Subpixel: 'static {
+    where I: GenericImage, I::Pixel: 'static {
     let mut out = ImageBuffer::new(image.width(), image.height());
     out.copy_from(image, 0, 0);
     draw_cross_mut(&mut out, color, x, y);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -46,9 +46,7 @@ use num::{
 // TODO: but this is still _really_ slow. fix!
 pub fn box_filter<I>(image: &I, x_radius: u32, y_radius: u32)
         -> VecBuffer<Luma<u8>>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static,
-          I::Pixel: 'static,
-          <I::Pixel as Pixel>::Subpixel: 'static {
+    where I: GenericImage<Pixel=Luma<u8>>{
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
@@ -91,9 +89,9 @@ pub fn box_filter<I>(image: &I, x_radius: u32, y_radius: u32)
 /// kernels h_filter and v_filter.
 pub fn separable_filter<I, K>(image: &I, h_kernel: &[K], v_kernel: &[K])
         -> VecBuffer<I::Pixel>
-    where I: GenericImage + 'static,
+    where I: GenericImage,
           I::Pixel: HasBlack + 'static,
-          <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K> + 'static,
+          <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K> ,
           K: Num + Copy {
     let h = horizontal_filter(image, h_kernel);
     let v = vertical_filter(&h, v_kernel);
@@ -104,9 +102,9 @@ pub fn separable_filter<I, K>(image: &I, h_kernel: &[K], v_kernel: &[K])
 /// kernel filter with itself.
 pub fn separable_filter_equal<I, K>(image: &I, kernel: &[K])
         -> VecBuffer<I::Pixel>
-    where I: GenericImage + 'static,
+    where I: GenericImage,
           I::Pixel: HasBlack + 'static,
-          <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K> + 'static,
+          <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K>,
           K: Num + Copy {
     separable_filter(image, kernel, kernel)
 }
@@ -116,9 +114,9 @@ pub fn separable_filter_equal<I, K>(image: &I, kernel: &[K])
 /// type K.
 pub fn horizontal_filter<I, K>(image: &I, kernel: &[K])
         -> VecBuffer<I::Pixel>
-    where I: GenericImage + 'static,
+    where I: GenericImage,
           I::Pixel: HasBlack + 'static,
-          <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K> + 'static,
+          <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K>,
           K: Num + Copy {
 
     let (width, height) = image.dimensions();
@@ -162,9 +160,9 @@ pub fn horizontal_filter<I, K>(image: &I, kernel: &[K])
 // TODO: shares too much code with horizontal_filter
 pub fn vertical_filter<I, K>(image: &I, kernel: &[K])
         -> VecBuffer<I::Pixel>
-    where I: GenericImage + 'static,
+    where I: GenericImage,
           I::Pixel: HasBlack + 'static,
-          <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K> + 'static,
+          <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K>,
           K: Num + Copy {
 
     let (width, height) = image.dimensions();
@@ -204,26 +202,21 @@ pub fn vertical_filter<I, K>(image: &I, kernel: &[K])
 }
 
 pub fn copy<I>(image: &I) -> VecBuffer<I::Pixel>
-    where I: GenericImage + 'static,
-          I::Pixel: 'static,
-          <I::Pixel as Pixel>::Subpixel: 'static {
+    where I: GenericImage, I::Pixel: 'static {
     let mut out = ImageBuffer::new(image.width(), image.height());
     out.copy_from(image, 0, 0);
     out
 }
 
 fn accumulate<P, K>(acc: &mut [K], pixel: &P, weight: K, num_channels: usize)
-    where P: Pixel + 'static,
-          <P as Pixel>::Subpixel : ValueInto<K>,
-          K: Num + Copy {
+    where P: Pixel, <P as Pixel>::Subpixel : ValueInto<K>, K: Num + Copy {
     for i in 0..num_channels {
         acc[i as usize] = acc[i as usize] + cast(pixel.channels()[i]) * weight;
     }
 }
 
 fn clamp_acc<P, K>(acc: &[K], pixel: &mut P, num_channels: usize)
-    where P: Pixel + 'static,
-          <P as Pixel>::Subpixel: Clamp<K>,
+    where P: Pixel, <P as Pixel>::Subpixel: Clamp<K>,
           K: Copy {
     for i in 0..num_channels {
         pixel.channels_mut()[i] = P::Subpixel::clamp(acc[i]);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -23,7 +23,8 @@ use conv::{
 };
 
 use utils::{
-    cast
+    cast,
+    VecBuffer
 };
 
 use num::{
@@ -44,7 +45,7 @@ use num::{
 // TODO: number of operations is constant with kernel size,
 // TODO: but this is still _really_ slow. fix!
 pub fn box_filter<I>(image: &I, x_radius: u32, y_radius: u32)
-        -> ImageBuffer<Luma<u8>, Vec<u8>>
+        -> VecBuffer<Luma<u8>>
     where I: GenericImage<Pixel=Luma<u8>> + 'static,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -89,7 +90,7 @@ pub fn box_filter<I>(image: &I, x_radius: u32, y_radius: u32)
 /// Returns 2d correlation of view with the outer product of the 1d
 /// kernels h_filter and v_filter.
 pub fn separable_filter<I, K>(image: &I, h_kernel: &[K], v_kernel: &[K])
-        -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+        -> VecBuffer<I::Pixel>
     where I: GenericImage + 'static,
           I::Pixel: HasBlack + 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K> + 'static,
@@ -102,7 +103,7 @@ pub fn separable_filter<I, K>(image: &I, h_kernel: &[K], v_kernel: &[K])
 /// Returns 2d correlation of view with the outer product of the 1d
 /// kernel filter with itself.
 pub fn separable_filter_equal<I, K>(image: &I, kernel: &[K])
-        -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+        -> VecBuffer<I::Pixel>
     where I: GenericImage + 'static,
           I::Pixel: HasBlack + 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K> + 'static,
@@ -114,7 +115,7 @@ pub fn separable_filter_equal<I, K>(image: &I, kernel: &[K])
 /// Pads by continuity. Intermediate calculations are performed at
 /// type K.
 pub fn horizontal_filter<I, K>(image: &I, kernel: &[K])
-        -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+        -> VecBuffer<I::Pixel>
     where I: GenericImage + 'static,
           I::Pixel: HasBlack + 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K> + 'static,
@@ -160,7 +161,7 @@ pub fn horizontal_filter<I, K>(image: &I, kernel: &[K])
 /// Pads by continuity.
 // TODO: shares too much code with horizontal_filter
 pub fn vertical_filter<I, K>(image: &I, kernel: &[K])
-        -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+        -> VecBuffer<I::Pixel>
     where I: GenericImage + 'static,
           I::Pixel: HasBlack + 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K> + 'static,
@@ -202,7 +203,7 @@ pub fn vertical_filter<I, K>(image: &I, kernel: &[K])
     out
 }
 
-pub fn copy<I>(image: &I) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+pub fn copy<I>(image: &I) -> VecBuffer<I::Pixel>
     where I: GenericImage + 'static,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {

--- a/src/integralimage.rs
+++ b/src/integralimage.rs
@@ -25,7 +25,7 @@ use utils::{
 // TODO: Support more formats.
 // TODO: This is extremely slow. Fix that!
 pub fn integral_image<I>(image: &I) -> VecBuffer<Luma<u32>>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
+    where I: GenericImage<Pixel=Luma<u8>> {
     padded_integral_image(image, 0, 0)
 }
 
@@ -36,7 +36,7 @@ pub fn integral_image<I>(image: &I) -> VecBuffer<Luma<u32>>
 /// and height image.height() + 2 * y_padding.
 pub fn padded_integral_image<I>(image: &I, x_padding: u32, y_padding: u32)
         -> VecBuffer<Luma<u32>>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
+    where I: GenericImage<Pixel=Luma<u8>> {
 
     let (in_width, in_height) = image.dimensions();
     let out_width = in_width + 2 * x_padding;
@@ -97,7 +97,7 @@ pub fn padded_integral_image<I>(image: &I, x_padding: u32, y_padding: u32)
 /// for all rows in an image.
 // TODO: faster, more formats
 pub fn row_running_sum<I>(image: &I, row: u32, buffer: &mut [u32], padding: u32)
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
+    where I: GenericImage<Pixel=Luma<u8>> {
 
     let width = image.width();
     assert!(buffer.len() >= (width + 2 * padding) as usize,
@@ -129,7 +129,7 @@ pub fn row_running_sum<I>(image: &I, row: u32, buffer: &mut [u32], padding: u32)
 /// for all columns in an image.
 // TODO: faster, more formats
 pub fn column_running_sum<I>(image: &I, column: u32, buffer: &mut [u32], padding: u32)
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
+    where I: GenericImage<Pixel=Luma<u8>> {
 
     let height = image.height();
     assert!(buffer.len() >= (height + 2 * padding) as usize,

--- a/src/integralimage.rs
+++ b/src/integralimage.rs
@@ -17,10 +17,14 @@ use image::{
     ImageBuffer
 };
 
+use utils::{
+    VecBuffer
+};
+
 /// Computes the integral image of an 8bpp grayscale image.
 // TODO: Support more formats.
 // TODO: This is extremely slow. Fix that!
-pub fn integral_image<I>(image: &I) -> ImageBuffer<Luma<u32>, Vec<u32>>
+pub fn integral_image<I>(image: &I) -> VecBuffer<Luma<u32>>
     where I: GenericImage<Pixel=Luma<u8>> + 'static {
     padded_integral_image(image, 0, 0)
 }
@@ -31,7 +35,7 @@ pub fn integral_image<I>(image: &I) -> ImageBuffer<Luma<u32>, Vec<u32>>
 /// Returned image has width image.width() + 2 * x_padding
 /// and height image.height() + 2 * y_padding.
 pub fn padded_integral_image<I>(image: &I, x_padding: u32, y_padding: u32)
-        -> ImageBuffer<Luma<u32>, Vec<u32>>
+        -> VecBuffer<Luma<u32>>
     where I: GenericImage<Pixel=Luma<u8>> + 'static {
 
     let (in_width, in_height) = image.dimensions();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 
 #![feature(test)]
 
+#[cfg(test)]
+extern crate test;
+
 extern crate conv;
 
 extern crate image;
@@ -8,9 +11,6 @@ extern crate image;
 extern crate num;
 
 extern crate rand;
-
-#[cfg(test)]
-extern crate test;
 
 #[macro_use]
 pub mod utils;

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -28,13 +28,14 @@ use conv::{
 };
 
 use utils::{
-    cast
+    cast,
+    VecBuffer
 };
 
 /// Adds independent additive Gaussian noise to all channels
 /// of an image, with the given mean and standard deviation.
 pub fn gaussian_noise<I>(image: &I, mean: f64, stddev: f64, seed: usize)
-        -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+        -> VecBuffer<I::Pixel>
     where I: GenericImage + 'static,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<f64> + Clamp<f64> + 'static {
@@ -77,7 +78,7 @@ pub fn gaussian_noise_mut<I>(image: &mut I, mean: f64, stddev: f64, seed: usize)
 /// Converts pixels to black or white at the given rate. Black and
 /// white occur with equal probability.
 pub fn salt_and_pepper_noise<I>(image: &I, rate: f64, seed: usize)
-        -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+        -> VecBuffer<I::Pixel>
     where I: GenericImage + 'static,
           I::Pixel: HasBlack + HasWhite + 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -36,9 +36,9 @@ use utils::{
 /// of an image, with the given mean and standard deviation.
 pub fn gaussian_noise<I>(image: &I, mean: f64, stddev: f64, seed: usize)
         -> VecBuffer<I::Pixel>
-    where I: GenericImage + 'static,
+    where I: GenericImage,
           I::Pixel: 'static,
-          <I::Pixel as Pixel>::Subpixel: ValueInto<f64> + Clamp<f64> + 'static {
+          <I::Pixel as Pixel>::Subpixel: ValueInto<f64> + Clamp<f64> {
 
     let mut out = ImageBuffer::new(image.width(), image.height());
     out.copy_from(image, 0, 0);
@@ -49,9 +49,8 @@ pub fn gaussian_noise<I>(image: &I, mean: f64, stddev: f64, seed: usize)
 /// Adds independent additive Gaussian noise to all channels
 /// of an image in place, with the given mean and standard deviation.
 pub fn gaussian_noise_mut<I>(image: &mut I, mean: f64, stddev: f64, seed: usize)
-    where I: GenericImage + 'static,
-          I::Pixel: 'static,
-          <I::Pixel as Pixel>::Subpixel: ValueInto<f64> + Clamp<f64> + 'static {
+    where I: GenericImage,
+          <I::Pixel as Pixel>::Subpixel: ValueInto<f64> + Clamp<f64> {
 
     let seed_array: &[_] = &[seed];
     let mut rng: StdRng = SeedableRng::from_seed(seed_array);
@@ -79,9 +78,7 @@ pub fn gaussian_noise_mut<I>(image: &mut I, mean: f64, stddev: f64, seed: usize)
 /// white occur with equal probability.
 pub fn salt_and_pepper_noise<I>(image: &I, rate: f64, seed: usize)
         -> VecBuffer<I::Pixel>
-    where I: GenericImage + 'static,
-          I::Pixel: HasBlack + HasWhite + 'static,
-          <I::Pixel as Pixel>::Subpixel: 'static {
+    where I: GenericImage, I::Pixel: HasBlack + HasWhite + 'static {
 
     let mut out = ImageBuffer::new(image.width(), image.height());
     out.copy_from(image, 0, 0);
@@ -92,9 +89,7 @@ pub fn salt_and_pepper_noise<I>(image: &I, rate: f64, seed: usize)
 /// Converts pixels to black or white in place at the given rate. Black and
 /// white occur with equal probability.
 pub fn salt_and_pepper_noise_mut<I>(image: &mut I, rate: f64, seed: usize)
-    where I: GenericImage + 'static,
-          I::Pixel: HasBlack + HasWhite + 'static,
-          <I::Pixel as Pixel>::Subpixel: 'static {
+    where I: GenericImage, I::Pixel: HasBlack + HasWhite {
 
     let seed_array: &[_] = &[seed];
     let mut rng: StdRng = SeedableRng::from_seed(seed_array);

--- a/src/regionlabelling.rs
+++ b/src/regionlabelling.rs
@@ -6,6 +6,10 @@ use image::{
     Luma
 };
 
+use utils::{
+    VecBuffer
+};
+
 use unionfind::DisjointSetForest;
 
 use std::cmp;
@@ -19,7 +23,7 @@ pub enum Connectivity { Four, Eight }
 /// or 0 if it's in the background. Input pixels are treated as belonging
 /// to the background if and only if they have value 0.
 pub fn connected_components<I>(image: &I, conn: Connectivity)
-        -> ImageBuffer<Luma<u32>, Vec<u32>>
+        -> VecBuffer<Luma<u32>>
     where I: GenericImage<Pixel=Luma<u8>> + 'static {
 
     let (width, height) = image.dimensions();

--- a/src/regionlabelling.rs
+++ b/src/regionlabelling.rs
@@ -24,7 +24,7 @@ pub enum Connectivity { Four, Eight }
 /// to the background if and only if they have value 0.
 pub fn connected_components<I>(image: &I, conn: Connectivity)
         -> VecBuffer<Luma<u32>>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
+    where I: GenericImage<Pixel=Luma<u8>> {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,11 @@ use conv::{
     ValueInto
 };
 
+use image::{
+    ImageBuffer,
+    Pixel
+};
+
 /// Panics if any pixels differ between the two input images.
 #[macro_export]
 macro_rules! assert_pixels_eq {
@@ -86,3 +91,10 @@ pub fn cast<T, U>(x: T) -> U where T: ValueInto<U> {
         Err(_) => panic!("Failed to convert"),
     }
 }
+
+/// An ImageBuffer containing Pixels of type P with storage
+/// Vec<P::Subpixel>.
+// TODO: This produces a compiler warning about trait bounds
+// TODO: not being enforced in type definitions. In this case
+// TODO: they are. Can we get rid of the warning?
+pub type VecBuffer<P: Pixel> = ImageBuffer<P, Vec<P::Subpixel>>;


### PR DESCRIPTION
Uncontroversial: removing unnecessary 'static bounds.
Controversial: VecBuffer type alias, which produces a compiler warning about bounds not being checked in type aliases. The warning is spurious in this case as using the Subpixel associated type in the right of the definition means the bound is actually checked (I checked this by creating my own trait with matching associated type names and the compiler rejected it).