### PR TITLE
Corners

### DIFF
--- a/src/corners.rs
+++ b/src/corners.rs
@@ -270,33 +270,19 @@ fn is_corner_fast12<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
 /// True if the circle has a contiguous section of at least the given length, all
 /// of whose pixels have intensities strictly greater than the threshold.
 fn has_bright_span(circle: &[i16; 16], length: u8, threshold: i16) -> bool {
-
-    if length > 16 { return false; }
-
-    let mut nb_ok = 0u8;
-    let mut nb_ok_start = None;
-    let mut nb_ko = 16 - length;
-
-    for c in circle.iter() {
-        if *c > threshold {
-            nb_ok += 1;
-            if nb_ok == length { return true; }
-        } else {
-            if nb_ok_start.is_none() {
-                nb_ok_start = Some(nb_ok);
-            }
-            nb_ok = 0;
-	    nb_ko -= 1;
-	    if nb_ko == 0 { return false; }
-        }
-    }
-
-    nb_ok + nb_ok_start.unwrap() >= length
+    search_span(circle, length, |c| *c > threshold)
 }
 
 /// True if the circle has a contiguous section of at least the given length, all
 /// of whose pixels have intensities strictly less than the threshold.
 fn has_dark_span(circle: &[i16; 16], length: u8, threshold: i16) -> bool {
+    search_span(circle, length, |c| *c < threshold)   
+}
+
+/// True if the circle has a contiguous section of at least the given length, all
+/// of whose pixels match f condition.
+fn search_span<F>(circle: &[i16; 16], length: u8, f: F) -> bool 
+    where F: Fn(&i16) -> bool {
     
     if length > 16 { return false; }
 
@@ -305,7 +291,7 @@ fn has_dark_span(circle: &[i16; 16], length: u8, threshold: i16) -> bool {
     let mut nb_ko = 16 - length;
 
     for c in circle.iter() {
-        if *c < threshold {
+        if f(c) {
             nb_ok += 1;
             if nb_ok == length { return true; }
         } else {

--- a/src/corners.rs
+++ b/src/corners.rs
@@ -269,8 +269,11 @@ fn is_corner_fast12<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
 
 /// True if the circle has a contiguous section of at least the given length, all
 /// of whose pixels have intensities strictly greater than the threshold.
-fn has_bright_span(circle: &[i16; 16], length: usize, threshold: i16) -> bool {
-    let mut nb_ok = 0;
+fn has_bright_span(circle: &[i16; 16], length: u8, threshold: i16) -> bool {
+
+    if length > 16 { return false; }
+
+    let mut nb_ok = 0u8;
     let mut nb_ok_start = None;
 
     for c in circle.iter() {
@@ -290,8 +293,11 @@ fn has_bright_span(circle: &[i16; 16], length: usize, threshold: i16) -> bool {
 
 /// True if the circle has a contiguous section of at least the given length, all
 /// of whose pixels have intensities strictly less than the threshold.
-fn has_dark_span(circle: &[i16; 16], length: usize, threshold: i16) -> bool {
-    let mut nb_ok = 0;
+fn has_dark_span(circle: &[i16; 16], length: u8, threshold: i16) -> bool {
+    
+    if length > 16 { return false; }
+
+    let mut nb_ok = 0u8;
     let mut nb_ok_start = None;
 
     for c in circle.iter() {

--- a/src/corners.rs
+++ b/src/corners.rs
@@ -275,6 +275,7 @@ fn has_bright_span(circle: &[i16; 16], length: u8, threshold: i16) -> bool {
 
     let mut nb_ok = 0u8;
     let mut nb_ok_start = None;
+    let mut nb_ko = 16 - length;
 
     for c in circle.iter() {
         if *c > threshold {
@@ -285,6 +286,8 @@ fn has_bright_span(circle: &[i16; 16], length: u8, threshold: i16) -> bool {
                 nb_ok_start = Some(nb_ok);
             }
             nb_ok = 0;
+	    nb_ko -= 1;
+	    if nb_ko == 0 { return false; }
         }
     }
 
@@ -299,6 +302,7 @@ fn has_dark_span(circle: &[i16; 16], length: u8, threshold: i16) -> bool {
 
     let mut nb_ok = 0u8;
     let mut nb_ok_start = None;
+    let mut nb_ko = 16 - length;
 
     for c in circle.iter() {
         if *c < threshold {
@@ -309,6 +313,8 @@ fn has_dark_span(circle: &[i16; 16], length: u8, threshold: i16) -> bool {
                 nb_ok_start = Some(nb_ok);
             }
             nb_ok = 0;
+	    nb_ko -= 1;
+	    if nb_ko == 0 { return false; }
         }
     }
 
@@ -385,6 +391,20 @@ mod test {
             10, 10, 00, 00, 00, 10, 10]).unwrap();
 
         assert_eq!(is_corner_fast12(&image, 8, 3, 3), false);
+    }
+
+    #[bench]
+    fn bench_is_corner_fast12_12_noncontiguous(b: &mut Bencher) {
+        let image: GrayImage = ImageBuffer::from_raw(7, 7, vec![
+            10, 10, 00, 00, 00, 10, 10,
+            10, 00, 10, 10, 10, 00, 10,
+            00, 10, 10, 10, 10, 10, 10,
+            00, 10, 10, 10, 10, 10, 10,
+            10, 10, 10, 10, 10, 10, 00,
+            10, 00, 10, 10, 10, 10, 10,
+            10, 10, 00, 00, 00, 10, 10]).unwrap();
+
+	b.iter(||is_corner_fast12(&image, 8, 3, 3));
     }
 
     #[test]


### PR DESCRIPTION
Some more optimization on corner bright/dark corner check.
1- use a generic function `search_span`
2- use `u8` instead of `usize` for length
3- early return `false` if `length > 16` (no impact on perf and avoids a panic)
4- count items not matching condition: as length is bigger than 16/2, nb_ko will probably reach 0 before nb_ok reaches length.

```
test corners::test::bench_is_corner_fast12_12_noncontiguous           ... bench:          31 ns/iter (+/- 3)
test corners::test::bench_is_corner_fast9_9_contiguous_lighter_pixels ... bench:          30 ns/iter (+/- 1)
```