### PR TITLE
use more ImageBuffer::from_raw

### DIFF
--- a/src/integralimage.rs
+++ b/src/integralimage.rs
@@ -44,8 +44,7 @@ pub fn padded_integral_image<I>(image: &I, x_padding: u32, y_padding: u32)
     let out_width = in_width + 2 * x_padding;
     let out_height = in_height + 2 * y_padding;
 
-    let mut out: ImageBuffer<Luma<u32>, Vec<u32>>
-        = ImageBuffer::new(out_width, out_height);
+    let mut out = Vec::with_capacity((out_width * out_height) as usize);
 
     for y in 0..out_height {
         for x in 0..out_width {
@@ -72,9 +71,11 @@ pub fn padded_integral_image<I>(image: &I, x_padding: u32, y_padding: u32)
             }
 
             let p = image.get_pixel(x_in, y_in);
-            out.put_pixel(x, y, Luma([p[0] as u32]));
+            out.push(p[0] as u32);
         }
     }
+
+    let mut out = ImageBuffer::<Luma<u32>, Vec<u32>>::from_raw(out_width, out_height, out).unwrap();
 
     for x in 1..out_width {
         (*out.get_pixel_mut(x, 0))[0] += out.get_pixel(x - 1, 0)[0];

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,12 @@
 //! Utils for testing and debugging.
 
 use image::{
+    ImageBuffer,
     DynamicImage,
     GenericImage,
     GrayImage,
-    Luma,
     open,
     Pixel,
-    Rgb,
     RgbImage
 };
 
@@ -124,29 +123,31 @@ pub fn load_image_or_panic(path: &Path) -> DynamicImage {
 /// similar to natural images - it's just a convenience method
 /// to produce an image that's not constant.
 pub fn gray_bench_image(width: u32, height: u32) -> GrayImage {
-    let mut image = GrayImage::new(width, height);
-    for y in 0..image.height() {
-        for x in 0..image.width() {
+    let mut out = Vec::with_capacity((width * height) as usize);
+    for y in 0..height {
+        for x in 0..width {
             let intensity = (x % 7 + y % 6) as u8;
-            image.put_pixel(x, y, Luma([intensity]));
+            out.push(intensity);
         }
     }
-    image
+    ImageBuffer::from_raw(width, height, out).unwrap()
 }
 
 /// RGB image to use in benchmarks. See comment on gray_bench_image.
 pub fn rgb_bench_image(width: u32, height: u32) -> RgbImage {
     use std::cmp;
-    let mut image = RgbImage::new(width, height);
-    for y in 0..image.height() {
-        for x in 0..image.width() {
+    let mut out = Vec::with_capacity((width * height * 3) as usize);
+    for y in 0..height {
+        for x in 0..width {
             let r = (x % 7 + y % 6) as u8;
             let g = 255u8 - r;
             let b = cmp::min(r, g);
-            image.put_pixel(x, y, Rgb([r, g, b]));
+            out.push(r);
+            out.push(g);
+            out.push(b);
         }
     }
-    image
+    ImageBuffer::from_raw(width, height, out).unwrap()
 }
 
 /// Wrapper for GrayImage to allow us to write an Arbitrary instance.
@@ -163,14 +164,14 @@ impl Clone for GrayTestImage {
 impl Arbitrary for GrayTestImage {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let (width, height) = small_image_dimensions(g);
-        let mut image = GrayImage::new(width, height);
-        for y in 0..height {
-            for x in 0..width {
+        let mut out = Vec::with_capacity((width * height * 3) as usize);
+        for _ in 0..height {
+            for _ in 0..width {
                 let val: u8 = g.gen();
-                image.put_pixel(x, y, Luma([val]));
+                out.push(val);
             }
         }
-        GrayTestImage(image)
+        GrayTestImage(ImageBuffer::from_raw(width, height, out).unwrap())
     }
 }
 
@@ -193,16 +194,18 @@ impl Clone for RgbTestImage {
 impl Arbitrary for RgbTestImage {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let (width, height) = small_image_dimensions(g);
-        let mut image = RgbImage::new(width, height);
-        for y in 0..height {
-            for x in 0..width {
+        let mut out = Vec::with_capacity((width * height * 3) as usize);
+        for _ in 0..height {
+            for _ in 0..width {
                 let red: u8 = g.gen();
                 let green: u8 = g.gen();
                 let blue: u8 = g.gen();
-                image.put_pixel(x, y, Rgb([red, green, blue]));
+                out.push(red);
+                out.push(green);
+                out.push(blue);
             }
         }
-        RgbTestImage(image)
+        RgbTestImage(ImageBuffer::from_raw(width, height, out).unwrap())
     }
 }
 


### PR DESCRIPTION
Work with `Vec` instead of ImageBuffer whenever possible to feed the buffer only once. 
Boost depends of the size of the image, the bigger the size the bigger the boost:
- For most benches (3x3): 10% improvement
- For translation bench (500x500): 45%

```
before
test affine::test::bench_rotate_bilinear                              ... bench:     709,819 ns/iter (+/- 21,843)
test affine::test::bench_rotate_nearest                               ... bench:     483,502 ns/iter (+/- 8,667)
test affine::test::bench_translate                                    ... bench:   1,181,222 ns/iter (+/- 27,135)
test contrast::test::bench_equalize_histogram                         ... bench:   4,775,053 ns/iter (+/- 91,165)
test corners::test::bench_is_corner_fast12_12_noncontiguous           ... bench:          33 ns/iter (+/- 0)
test corners::test::bench_is_corner_fast9_9_contiguous_lighter_pixels ... bench:          35 ns/iter (+/- 2)
test filter::test::bench_box_filter                                   ... bench:   5,998,076 ns/iter (+/- 190,131)
test filter::test::bench_filter3x3_i32_filter                         ... bench:   3,776,641 ns/iter (+/- 109,675)
test filter::test::bench_horizontal_filter                            ... bench:  11,202,408 ns/iter (+/- 209,251)
test filter::test::bench_separable_filter                             ... bench:   7,888,068 ns/iter (+/- 131,072)
test filter::test::bench_vertical_filter                              ... bench:  11,344,529 ns/iter (+/- 393,630)
test integralimage::test::bench_column_running_sum                    ... bench:       4,405 ns/iter (+/- 159)
test integralimage::test::bench_integral_image                        ... bench:   1,787,221 ns/iter (+/- 80,285)
test integralimage::test::bench_row_running_sum                       ... bench:       4,116 ns/iter (+/- 192)
test suppress::test::bench_local_maxima_dense                         ... bench:      47,196 ns/iter (+/- 583)
test suppress::test::bench_local_maxima_sparse                        ... bench:      47,204 ns/iter (+/- 1,802)
test suppress::test::bench_suppress_non_maximum_decreasing_gradient   ... bench:     245,429 ns/iter (+/- 7,970)
test suppress::test::bench_suppress_non_maximum_increasing_gradient   ... bench:     271,580 ns/iter (+/- 10,141)
test suppress::test::bench_suppress_non_maximum_noise                 ... bench:     307,741 ns/iter (+/- 7,124)

after
test affine::test::bench_rotate_bilinear                              ... bench:     633,902 ns/iter (+/- 11,534)
test affine::test::bench_rotate_nearest                               ... bench:     428,940 ns/iter (+/- 7,492)
test affine::test::bench_translate                                    ... bench:     649,609 ns/iter (+/- 37,170)
test contrast::test::bench_equalize_histogram                         ... bench:   4,470,510 ns/iter (+/- 96,611)
test corners::test::bench_is_corner_fast12_12_noncontiguous           ... bench:          33 ns/iter (+/- 0)
test corners::test::bench_is_corner_fast9_9_contiguous_lighter_pixels ... bench:          37 ns/iter (+/- 5)
test filter::test::bench_box_filter                                   ... bench:   5,644,614 ns/iter (+/- 109,773)
test filter::test::bench_filter3x3_i32_filter                         ... bench:   3,405,808 ns/iter (+/- 89,963)
test filter::test::bench_horizontal_filter                            ... bench:  10,775,888 ns/iter (+/- 303,335)
test filter::test::bench_separable_filter                             ... bench:   7,611,823 ns/iter (+/- 185,321)
test filter::test::bench_vertical_filter                              ... bench:  10,852,682 ns/iter (+/- 243,694)
test integralimage::test::bench_column_running_sum                    ... bench:       4,485 ns/iter (+/- 120)
test integralimage::test::bench_integral_image                        ... bench:   1,580,036 ns/iter (+/- 42,382)
test integralimage::test::bench_row_running_sum                       ... bench:       4,116 ns/iter (+/- 99)
test suppress::test::bench_local_maxima_dense                         ... bench:      36,362 ns/iter (+/- 3,900)
test suppress::test::bench_local_maxima_sparse                        ... bench:      47,602 ns/iter (+/- 4,124)
test suppress::test::bench_suppress_non_maximum_decreasing_gradient   ... bench:     223,764 ns/iter (+/- 18,522)
test suppress::test::bench_suppress_non_maximum_increasing_gradient   ... bench:     242,986 ns/iter (+/- 11,855)
test suppress::test::bench_suppress_non_maximum_noise                 ... bench:     284,205 ns/iter (+/- 10,430)
```