### PR TITLE
Use unsafe_get/put_pixel

### DIFF
--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -67,10 +67,12 @@ pub fn threshold_mut<I>(image: &mut I, thresh: u8)
 {
     for y in 0..image.height() {
         for x in 0..image.width() {
-            if image.get_pixel(x, y)[0] as u8 <= thresh {
-                image.put_pixel(x, y, Luma([0]));
-            } else {
-                image.put_pixel(x, y, Luma([255]));
+            unsafe {
+                if image.unsafe_get_pixel(x, y)[0] as u8 <= thresh {
+                    image.unsafe_put_pixel(x, y, Luma([0]));
+                } else {
+                    image.unsafe_put_pixel(x, y, Luma([255]));
+                }
             }
         }
     }
@@ -114,10 +116,10 @@ pub fn equalize_histogram_mut<I>(image: &mut I)
 
     for y in 0..image.height() {
         for x in 0..image.width() {
-            let original = image.get_pixel(x, y)[0] as usize;
+            let original = unsafe { image.unsafe_get_pixel(x, y)[0] as usize };
             let fraction = hist[original] as f32 / total;
             let out = f32::min(255f32, 255f32 * fraction);
-            image.put_pixel(x, y, Luma([out as u8]));
+            unsafe { image.unsafe_put_pixel(x, y, Luma([out as u8])); }
         }
     }
 }
@@ -145,8 +147,10 @@ pub fn match_histogram_mut<I, J>(image: &mut I, target: &J)
 
     for y in 0..image.height() {
         for x in 0..image.width() {
-            let pix = image.get_pixel(x, y)[0] as usize;
-            image.put_pixel(x, y, Luma([lut[pix] as u8]));
+            unsafe {
+                let pix = image.unsafe_get_pixel(x, y)[0] as usize;
+                image.unsafe_put_pixel(x, y, Luma([lut[pix] as u8]));
+            }
         }
     }
 }

--- a/src/corners.rs
+++ b/src/corners.rs
@@ -151,15 +151,15 @@ fn is_corner_fast9<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
         return false;
     }
 
-    let c = image.get_pixel(x, y)[0];
+    let c = unsafe { image.unsafe_get_pixel(x, y)[0] };
     let low_thresh: i16  = c as i16 - threshold as i16;
     let high_thresh: i16 = c as i16 + threshold as i16;
 
     // See Note [FAST circle labels]
-    let p0  = image.get_pixel(x, y - 3)[0] as i16;
-    let p8  = image.get_pixel(x, y + 3)[0] as i16;
-    let p4  = image.get_pixel(x + 3, y)[0] as i16;
-    let p12 = image.get_pixel(x - 3, y)[0] as i16;
+    let p0 = unsafe { image.unsafe_get_pixel(x, y - 3)[0] as i16 };
+    let p8 = unsafe { image.unsafe_get_pixel(x, y + 3)[0] as i16 };
+    let p4  = unsafe { image.unsafe_get_pixel(x + 3, y)[0] as i16 };
+    let p12 = unsafe { image.unsafe_get_pixel(x - 3, y)[0] as i16 };
 
     let above = (p0  > high_thresh && p4  > high_thresh) ||
                 (p4  > high_thresh && p8  > high_thresh) ||
@@ -175,24 +175,7 @@ fn is_corner_fast9<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
         return false;
     }
 
-    let mut pixels = [0i16; 16];
-
-    pixels[0]  = p0;
-    pixels[1]  = image.get_pixel(x + 1, y - 3)[0] as i16;
-    pixels[2]  = image.get_pixel(x + 2, y - 2)[0] as i16;
-    pixels[3]  = image.get_pixel(x + 3, y - 1)[0] as i16;
-    pixels[4]  = p4;
-    pixels[5]  = image.get_pixel(x + 3, y + 1)[0] as i16;
-    pixels[6]  = image.get_pixel(x + 2, y + 2)[0] as i16;
-    pixels[7]  = image.get_pixel(x + 1, y + 3)[0] as i16;
-    pixels[8]  = p8;
-    pixels[9]  = image.get_pixel(x - 1, y + 3)[0] as i16;
-    pixels[10] = image.get_pixel(x - 2, y + 2)[0] as i16;
-    pixels[11] = image.get_pixel(x - 3, y + 1)[0] as i16;
-    pixels[12] = p12;
-    pixels[13] = image.get_pixel(x - 3, y - 1)[0] as i16;
-    pixels[14] = image.get_pixel(x - 2, y - 2)[0] as i16;
-    pixels[15] = image.get_pixel(x - 1, y - 3)[0] as i16;
+    let pixels = unsafe { get_circle(image, x, y, p0, p4, p8, p12) };
 
     // above and below could both be true
     (above && has_bright_span(&pixels, 9, high_thresh)) ||
@@ -208,13 +191,13 @@ fn is_corner_fast12<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
         return false;
     }
 
-    let c = image.get_pixel(x, y)[0];
+    let c = unsafe { image.unsafe_get_pixel(x, y)[0] };
     let low_thresh: i16  = c as i16 - threshold as i16;
     let high_thresh: i16 = c as i16 + threshold as i16;
 
     // See Note [FAST circle labels]
-    let p0 = image.get_pixel(x, y - 3)[0] as i16;
-    let p8 = image.get_pixel(x, y + 3)[0] as i16;
+    let p0 = unsafe { image.unsafe_get_pixel(x, y - 3)[0] as i16 };
+    let p8 = unsafe { image.unsafe_get_pixel(x, y + 3)[0] as i16 };
 
     let mut above = p0 > high_thresh && p8 > high_thresh;
     let mut below = p0 < low_thresh  && p8 < low_thresh;
@@ -223,8 +206,8 @@ fn is_corner_fast12<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
         return false;
     }
 
-    let p4  = image.get_pixel(x + 3, y)[0] as i16;
-    let p12 = image.get_pixel(x - 3, y)[0] as i16;
+    let p4  = unsafe { image.unsafe_get_pixel(x + 3, y)[0] as i16 };
+    let p12 = unsafe { image.unsafe_get_pixel(x - 3, y)[0] as i16 };
 
     above = above && ((p4 > high_thresh) || (p12 > high_thresh));
     below = below && ((p4 < low_thresh)  || (p12 < low_thresh));
@@ -239,24 +222,7 @@ fn is_corner_fast12<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
     // TODO: need to distinguish between GenericImages and ImageBuffers.
     // TODO: We can also reduce the number of checks we do below.
 
-    let mut pixels = [0i16; 16];
-
-    pixels[0]  = p0;
-    pixels[1]  = image.get_pixel(x + 1, y - 3)[0] as i16;
-    pixels[2]  = image.get_pixel(x + 2, y - 2)[0] as i16;
-    pixels[3]  = image.get_pixel(x + 3, y - 1)[0] as i16;
-    pixels[4]  = p4;
-    pixels[5]  = image.get_pixel(x + 3, y + 1)[0] as i16;
-    pixels[6]  = image.get_pixel(x + 2, y + 2)[0] as i16;
-    pixels[7]  = image.get_pixel(x + 1, y + 3)[0] as i16;
-    pixels[8]  = p8;
-    pixels[9]  = image.get_pixel(x - 1, y + 3)[0] as i16;
-    pixels[10] = image.get_pixel(x - 2, y + 2)[0] as i16;
-    pixels[11] = image.get_pixel(x - 3, y + 1)[0] as i16;
-    pixels[12] = p12;
-    pixels[13] = image.get_pixel(x - 3, y - 1)[0] as i16;
-    pixels[14] = image.get_pixel(x - 2, y - 2)[0] as i16;
-    pixels[15] = image.get_pixel(x - 1, y - 3)[0] as i16;
+    let pixels = unsafe { get_circle(image, x, y, p0, p4, p8, p12) };
 
     // Exactly one of above or below is true
     if above {
@@ -265,6 +231,31 @@ fn is_corner_fast12<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
     else {
         has_dark_span(&pixels, 12, low_thresh)
     }
+}
+
+#[inline]
+unsafe fn get_circle<I>(image: &I, x: u32, y: u32, 
+                        p0: i16, p4: i16, p8: i16, p12: i16) -> [i16; 16]
+    where I: GenericImage<Pixel=Luma<u8>>
+{
+    [
+        p0,
+        image.unsafe_get_pixel(x + 1, y - 3)[0] as i16,
+        image.unsafe_get_pixel(x + 2, y - 2)[0] as i16,
+        image.unsafe_get_pixel(x + 3, y - 1)[0] as i16,
+        p4,
+        image.unsafe_get_pixel(x + 3, y + 1)[0] as i16,
+        image.unsafe_get_pixel(x + 2, y + 2)[0] as i16,
+        image.unsafe_get_pixel(x + 1, y + 3)[0] as i16,
+        p8,
+        image.unsafe_get_pixel(x - 1, y + 3)[0] as i16,
+        image.unsafe_get_pixel(x - 2, y + 2)[0] as i16,
+        image.unsafe_get_pixel(x - 3, y + 1)[0] as i16,
+        p12,
+        image.unsafe_get_pixel(x - 3, y - 1)[0] as i16,
+        image.unsafe_get_pixel(x - 2, y - 2)[0] as i16,
+        image.unsafe_get_pixel(x - 1, y - 3)[0] as i16,
+    ]
 }
 
 /// True if the circle has a contiguous section of at least the given length, all

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -30,7 +30,8 @@ pub fn draw_cross_mut<I>(image: &mut I, color: I::Pixel, x: i32, y: i32)
             }
 
             if stencil[idx(sx, sy)] == 1u8 {
-                image.put_pixel(ix as u32, iy as u32, color);
+                // bound checks already done
+                unsafe { image.unsafe_put_pixel(ix as u32, iy as u32, color); }
             }
         }
     }
@@ -93,10 +94,12 @@ pub fn draw_line_segment_mut<I>(image: &mut I, start: (f32, f32), end: (f32, f32
     let mut y = y0 as i32;
 
     for x in x0 as i32..(x1 + 1f32) as i32 {
-        if is_steep && in_bounds(y, x) {
-            image.put_pixel(y as u32, x as u32, color);
-        } else if in_bounds(x, y) {
-            image.put_pixel(x as u32, y as u32, color);
+        unsafe {
+            if is_steep && in_bounds(y, x) {
+                image.unsafe_put_pixel(y as u32, x as u32, color);
+            } else if in_bounds(x, y) {
+                image.unsafe_put_pixel(x as u32, y as u32, color);
+            }
         }
         error -= dy;
         if error < 0f32 {
@@ -155,7 +158,7 @@ pub fn draw_filled_rect_mut<I>(image: &mut I, rect: Rect, color: I::Pixel)
             for dx in 0..intersection.width() {
                 let x = intersection.left() as u32 + dx;
                 let y = intersection.top() as u32 + dy;
-                image.put_pixel(x, y, color);
+                unsafe { image.unsafe_put_pixel(x, y, color); }
             }
         }
     }

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -85,10 +85,12 @@ pub fn sobel_gradients<I>(image: &I) -> VecBuffer<Luma<u16>>
 
     for y in 0..height {
         for x in 0..width {
-            let h = horizontal.get_pixel(x, y)[0] as f32;
-            let v = vertical.get_pixel(x, y)[0] as f32;
-            let m = (h.powi(2) + v.powi(2)).sqrt() as u16;
-            out.put_pixel(x, y, Luma([m]));
+            unsafe {
+                let h = horizontal.unsafe_get_pixel(x, y)[0] as f32;
+                let v = vertical.unsafe_get_pixel(x, y)[0] as f32;
+                let m = (h.powi(2) + v.powi(2)).sqrt() as u16;
+                out.unsafe_put_pixel(x, y, Luma([m]));
+            }
         }
     }
 

--- a/src/haar.rs
+++ b/src/haar.rs
@@ -310,11 +310,13 @@ pub fn draw_haar_filter_mut<I>(image: &mut I, filter: HaarFilter)
                 }
             }
             assert!(weight == 0 || weight == 1 || weight == -1);
-            if weight > 0 {
-                image.put_pixel(x, y, I::Pixel::white());
-            }
-            if weight < 0 {
-                image.put_pixel(x, y, I::Pixel::black());
+            unsafe {
+                if weight > 0 {
+                    image.unsafe_put_pixel(x, y, I::Pixel::white());
+                }
+                if weight < 0 {
+                    image.unsafe_put_pixel(x, y, I::Pixel::black());
+                }
             }
         }
     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -57,7 +57,8 @@ pub fn map_subpixels<I, P, F, S>(image: &I, f: F) -> VecBuffer<ChannelMap<P, S>>
             let mut out_channels = out.get_pixel_mut(x, y).channels_mut();
             for c in 0..P::channel_count() {
                 out_channels[c as usize]
-                    = f(image.get_pixel(x, y).channels()[c as usize]);
+                    = f(unsafe {*image.unsafe_get_pixel(x, y)
+                        .channels().get_unchecked(c as usize) });
             }
         }
     }
@@ -77,8 +78,10 @@ pub fn map_colors<I, P, Q, F>(image: &I, f: F) -> VecBuffer<Q>
 
     for y in 0..height {
         for x in 0..width {
-            let pix = image.get_pixel(x, y);
-            out.put_pixel(x, y, f(pix));
+            unsafe {
+                let pix = image.unsafe_get_pixel(x, y);
+                out.unsafe_put_pixel(x, y, f(pix));
+            }
         }
     }
 
@@ -97,8 +100,10 @@ pub fn map_pixels<I, P, Q, F>(image: &I, f: F) -> VecBuffer<Q>
 
     for y in 0..height {
         for x in 0..width {
-            let pix = image.get_pixel(x, y);
-            out.put_pixel(x, y, f(x, y, pix));
+            unsafe {
+                let pix = image.unsafe_get_pixel(x, y);
+                out.unsafe_put_pixel(x, y, f(x, y, pix));
+            }
         }
     }
 

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -59,7 +59,7 @@ pub fn gaussian_noise_mut<I>(image: &mut I, mean: f64, stddev: f64, seed: usize)
 
     for y in 0..image.height() {
         for x in 0..image.width() {
-            let mut pix = image.get_pixel(x, y);
+            let mut pix = unsafe { image.unsafe_get_pixel(x, y) };
             let num_channels = I::Pixel::channel_count() as usize;
 
             for c in 0..num_channels {
@@ -69,7 +69,7 @@ pub fn gaussian_noise_mut<I>(image: &mut I, mean: f64, stddev: f64, seed: usize)
                     = <I::Pixel as Pixel>::Subpixel::clamp(channel + noise);
             }
 
-            image.put_pixel(x, y, pix);
+            unsafe { image.unsafe_put_pixel(x, y, pix) };
         }
     }
 }
@@ -103,11 +103,13 @@ pub fn salt_and_pepper_noise_mut<I>(image: &mut I, rate: f64, seed: usize)
                 continue;
             }
 
-            if uniform.ind_sample(&mut rng) >= 0.5 {
-                image.put_pixel(x, y, I::Pixel::white());
-            }
-            else {
-                image.put_pixel(x, y, I::Pixel::black());
+            unsafe {
+                if uniform.ind_sample(&mut rng) >= 0.5 {
+                    image.unsafe_put_pixel(x, y, I::Pixel::white());
+                }
+                else {
+                    image.unsafe_put_pixel(x, y, I::Pixel::black());
+                }
             }
         }
     }


### PR DESCRIPTION
This PR change most `get_pixel`/`put_pixel` into their unsafe equivalent `unsafe_get_pixel`/`unsafe_put_pixel`.

These functions are unsafe because there is no bound checks. However those bounds check are most of the time already enforced within the fns by looping in 0..height x 0..width.

It results in a very nice speedup in most benches but adds a huge amount of `unsafe`s. We may probably need to refactor in a the future so only very few functions do use unsafes.

There is also a simplification of the code for `suppress_non_maximum_mut` in a separate commit.

```
before
test affine::test::bench_rotate_bilinear                              ... bench:     665,256 ns/iter (+/- 5,648)
test affine::test::bench_rotate_nearest                               ... bench:     356,280 ns/iter (+/- 2,612)
test affine::test::bench_translate                                    ... bench:     507,632 ns/iter (+/- 4,090)
test contrast::test::bench_equalize_histogram                         ... bench:   3,526,780 ns/iter (+/- 20,114)
test corners::test::bench_is_corner_fast12_12_noncontiguous           ... bench:          27 ns/iter (+/- 0)
test corners::test::bench_is_corner_fast9_9_contiguous_lighter_pixels ... bench:          31 ns/iter (+/- 0)
test filter::test::bench_box_filter                                   ... bench:   4,587,544 ns/iter (+/- 20,103)
test filter::test::bench_filter3x3_i32_filter                         ... bench:   2,557,473 ns/iter (+/- 13,557)
test filter::test::bench_horizontal_filter                            ... bench:   9,357,790 ns/iter (+/- 141,952)
test filter::test::bench_separable_filter                             ... bench:   6,631,563 ns/iter (+/- 39,749)
test filter::test::bench_vertical_filter                              ... bench:   9,385,985 ns/iter (+/- 39,437)
test integralimage::test::bench_column_running_sum                    ... bench:       3,761 ns/iter (+/- 43)
test integralimage::test::bench_integral_image                        ... bench:   1,446,309 ns/iter (+/- 7,460)
test integralimage::test::bench_row_running_sum                       ... bench:       3,432 ns/iter (+/- 7)
test suppress::test::bench_local_maxima_dense                         ... bench:      45,662 ns/iter (+/- 947)
test suppress::test::bench_local_maxima_sparse                        ... bench:      44,744 ns/iter (+/- 206)
test suppress::test::bench_suppress_non_maximum_decreasing_gradient   ... bench:     182,820 ns/iter (+/- 1,010)
test suppress::test::bench_suppress_non_maximum_increasing_gradient   ... bench:     200,905 ns/iter (+/- 3,371)
test suppress::test::bench_suppress_non_maximum_noise                 ... bench:     228,426 ns/iter (+/- 2,115)


after
test affine::test::bench_rotate_bilinear                              ... bench:     631,805 ns/iter (+/- 8,626)
test affine::test::bench_rotate_nearest                               ... bench:     349,432 ns/iter (+/- 3,367)
test affine::test::bench_translate                                    ... bench:     224,115 ns/iter (+/- 1,665)
test contrast::test::bench_equalize_histogram                         ... bench:   2,350,830 ns/iter (+/- 17,506)
test corners::test::bench_is_corner_fast12_12_noncontiguous           ... bench:          24 ns/iter (+/- 0)
test corners::test::bench_is_corner_fast9_9_contiguous_lighter_pixels ... bench:          25 ns/iter (+/- 0)
test filter::test::bench_box_filter                                   ... bench:   4,349,047 ns/iter (+/- 9,687)
test filter::test::bench_filter3x3_i32_filter                         ... bench:   1,941,680 ns/iter (+/- 8,936)
test filter::test::bench_horizontal_filter                            ... bench:   9,162,881 ns/iter (+/- 32,956)
test filter::test::bench_separable_filter                             ... bench:   6,583,317 ns/iter (+/- 106,594)
test filter::test::bench_vertical_filter                              ... bench:   9,382,289 ns/iter (+/- 42,686)
test integralimage::test::bench_column_running_sum                    ... bench:       3,573 ns/iter (+/- 64)
test integralimage::test::bench_integral_image                        ... bench:   1,331,922 ns/iter (+/- 12,368)
test integralimage::test::bench_row_running_sum                       ... bench:       3,268 ns/iter (+/- 12)
test suppress::test::bench_local_maxima_dense                         ... bench:      46,297 ns/iter (+/- 7,117)
test suppress::test::bench_local_maxima_sparse                        ... bench:      44,729 ns/iter (+/- 150)
test suppress::test::bench_suppress_non_maximum_decreasing_gradient   ... bench:     116,466 ns/iter (+/- 478)
test suppress::test::bench_suppress_non_maximum_increasing_gradient   ... bench:     125,538 ns/iter (+/- 992)
test suppress::test::bench_suppress_non_maximum_noise                 ... bench:      78,835 ns/iter (+/- 390)
```
