### PR TITLE
Faster algorithm for suppress_non_maximum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 
 #![feature(test)]
+#![feature(step_by)]
 
 #[cfg(test)]
 extern crate test;


### PR DESCRIPTION
Before:

test suppress::test::bench_suppress_non_maximum_noise_1               ... bench:       8,752 ns/iter (+/- 899)
test suppress::test::bench_suppress_non_maximum_noise_3               ... bench:      10,548 ns/iter (+/- 3,702)
test suppress::test::bench_suppress_non_maximum_noise_7               ... bench:      11,583 ns/iter (+/- 7,222)

After:

test suppress::test::bench_suppress_non_maximum_noise_1               ... bench:       6,975 ns/iter (+/- 2,697)
test suppress::test::bench_suppress_non_maximum_noise_3               ... bench:       5,647 ns/iter (+/- 355)
test suppress::test::bench_suppress_non_maximum_noise_7               ... bench:       5,352 ns/iter (+/- 184)
