### PR TITLE
Less terrible implementation of integral image

### DIFF
--- a/src/integralimage.rs
+++ b/src/integralimage.rs
@@ -13,8 +13,6 @@ use definitions::{
     VecBuffer
 };
 
-use std::cmp;
-
 /// Computes the integral image of an 8bpp grayscale image.
 /// I is the integral image of an image F if I(x, y) is the
 /// sum of F(x', y') for x' <= x, y' <= y. i.e. each pixel


### PR DESCRIPTION
```
Before:

test integralimage::test::bench_integral_image                          ... bench:     918,737 ns/iter (+/- 120,489)

After:

test integralimage::test::bench_integral_image                          ... bench:     534,683 ns/iter (+/- 81,430)
```