### PR TITLE
Contrast

### DIFF
--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -199,6 +199,7 @@ mod test {
     use super::{
         cumulative_histogram,
         equalize_histogram,
+        equalize_histogram_mut,
         histogram,
         histogram_lut,
         otsu_level,
@@ -326,6 +327,14 @@ mod test {
         b.iter(|| {
             let equalized = equalize_histogram(&image);
             test::black_box(equalized);
+        });
+    }
+
+    #[bench]
+    fn bench_equalize_histogram_mut(b: &mut test::Bencher) {
+        let mut image = gray_bench_image(500, 500);
+        b.iter(|| {
+            test::black_box(equalize_histogram_mut(&mut image));
         });
     }
 

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -1,6 +1,7 @@
 //! Functions for manipulating the contrast of images.
 
 use image::{GenericImage, GrayImage, ImageBuffer, Luma};
+use definitions::VecBuffer;
 
 /// Returns the Otsu threshold level of an 8bpp image.
 /// This threshold will optimally binarize an image that
@@ -51,30 +52,17 @@ pub fn otsu_level<I>(image: &I) -> u8
 
 /// Returns a binarized image from an input 8bpp grayscale image
 /// obtained by applying the given threshold.
-pub fn threshold<I>(image: &I, thresh: u8) -> GrayImage
-    where I: GenericImage<Pixel = Luma<u8>>
-{
-    let mut out: GrayImage = ImageBuffer::new(image.width(), image.height());
-    out.copy_from(image, 0, 0);
+pub fn threshold(image: &VecBuffer<Luma<u8>>, thresh: u8) -> GrayImage {
+    let mut out = image.clone();
     threshold_mut(&mut out, thresh);
     out
 }
 
 /// Mutates given image to form a binarized version produced by applying
 /// the given threshold.
-pub fn threshold_mut<I>(image: &mut I, thresh: u8)
-    where I: GenericImage<Pixel = Luma<u8>>
-{
-    for y in 0..image.height() {
-        for x in 0..image.width() {
-            unsafe {
-                if image.unsafe_get_pixel(x, y)[0] as u8 <= thresh {
-                    image.unsafe_put_pixel(x, y, Luma([0]));
-                } else {
-                    image.unsafe_put_pixel(x, y, Luma([255]));
-                }
-            }
-        }
+pub fn threshold_mut(image: &mut VecBuffer<Luma<u8>>, thresh: u8) {
+    for c in image.iter_mut() {
+        *c = if *c as u8 <= thresh { 0 } else { 255 };
     }
 }
 

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -214,7 +214,9 @@ mod test {
         histogram,
         histogram_lut,
         otsu_level,
-        threshold};
+        threshold,
+        threshold_mut,
+    };
     use utils::gray_bench_image;
     use image::{GrayImage, ImageBuffer};
     use test;
@@ -336,6 +338,23 @@ mod test {
         b.iter(|| {
             let equalized = equalize_histogram(&image);
             test::black_box(equalized);
+        });
+    }
+
+    #[bench]
+    fn bench_threshold(b: &mut test::Bencher) {
+        let image = gray_bench_image(500, 500);
+        b.iter(|| {
+            let thresholded = threshold(&image, 125);
+            test::black_box(thresholded);
+        });
+    }
+    
+    #[bench]
+    fn bench_threshold_mut(b: &mut test::Bencher) {
+        let mut image = gray_bench_image(500, 500);
+        b.iter(|| {
+            test::black_box(threshold_mut(&mut image, 125));
         });
     }
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -12,6 +12,7 @@ extern crate test;
 extern crate imageproc;
 
 use std::path::Path;
+use image::ImageBuffer;
 
 use imageproc::utils::{
     load_image_or_panic


### PR DESCRIPTION
Use `VecBuffer` instead of `GenericImage`.
Added some more benchmarks (we may cherry-pick them on master ?).

```
before
test contrast::test::bench_threshold                                    ... bench:   1,175,968 ns/iter (+/- 12,929)
test contrast::test::bench_threshold_mut                                ... bench:     341,623 ns/iter (+/- 4,349)
test contrast::test::bench_equalize_histogram                           ... bench:   2,227,185 ns/iter (+/- 20,862)
test contrast::test::bench_equalize_histogram_mut                       ... bench:   1,432,186 ns/iter (+/- 33,085)

after
test contrast::test::bench_threshold                                    ... bench:      31,795 ns/iter (+/- 437)
test contrast::test::bench_threshold_mut                                ... bench:      12,227 ns/iter (+/- 274)
test contrast::test::bench_equalize_histogram                           ... bench:     948,128 ns/iter (+/- 11,067)
test contrast::test::bench_equalize_histogram_mut                       ... bench:     929,868 ns/iter (+/- 12,838)
```