### PR TITLE
Prevent drawing an extra line in draw_line_segment_mut

### DIFF
--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -95,10 +95,14 @@ pub fn draw_line_segment_mut<I>(image: &mut I, start: (f32, f32), end: (f32, f32
 
     for x in x0 as i32..(x1 + 1f32) as i32 {
         unsafe {
-            if is_steep && in_bounds(y, x) {
-                image.unsafe_put_pixel(y as u32, x as u32, color);
-            } else if in_bounds(x, y) {
-                image.unsafe_put_pixel(x as u32, y as u32, color);
+            if is_steep {
+                if in_bounds(y, x) {
+                    image.unsafe_put_pixel(y as u32, x as u32, color);
+                }
+            } else {
+                if in_bounds(x, y) {
+                    image.unsafe_put_pixel(x as u32, y as u32, color);
+                }
             }
         }
         error -= dy;


### PR DESCRIPTION
In cases where `is_steep` was `true`, (y, x) was out of bounds, but
(x, y) was in bounds, the `else` clause would draw an extra line segment by
mirroring the out-of-bounds part of the line into the image.

Example
```rust
extern crate image;
extern crate imageproc;

use image::{ImageBuffer, Rgb};

fn main() {
    let mut img = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(400, 200);
    let red = Rgb { data: [255, 0, 0]};
    imageproc::drawing::draw_line_segment_mut(&mut img, (-100., 500.), (400., -300.), red);
    img.save("line.png").unwrap();
}
```

Before:
![line-before](https://cloud.githubusercontent.com/assets/119951/16140705/5a2c84f8-3408-11e6-9010-1b66a26836f3.png)

After:
![line-after](https://cloud.githubusercontent.com/assets/119951/16140708/5ea167f6-3408-11e6-9d28-67b656bb5c9c.png)