### PR TITLE
Rename VecBuffer to Image, and start to use this as the standard input type instead of GenericImage

### DIFF
--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -1,7 +1,7 @@
 //! Functions for manipulating the contrast of images.
 
 use std::cmp::{min, max};
-use image::{GenericImage, GrayImage, ImageBuffer, Luma};
+use image::{GrayImage, ImageBuffer, Luma};
 use definitions::{HasBlack, HasWhite};
 use integralimage::{integral_image, sum_image_pixels};
 
@@ -10,9 +10,7 @@ use integralimage::{integral_image, sum_image_pixels};
 /// This algorithm compares each pixel's brightness with the average brightness of the pixels
 /// in the (2 * `block_radius` + 1) square block centered on it. If the pixel if at least as bright
 /// as the threshold then it will have a value of 255 in the output image, otherwise 0.
-pub fn adaptive_threshold<I>(image: &I, block_radius: u32) -> GrayImage
-     where I: GenericImage<Pixel = Luma<u8>>
-{
+pub fn adaptive_threshold(image: &GrayImage, block_radius: u32) -> GrayImage {
      assert!(block_radius > 0);
      let integral = integral_image(image);
      let mut out = ImageBuffer::from_pixel(image.width(), image.height(), Luma::black());
@@ -42,9 +40,7 @@ pub fn adaptive_threshold<I>(image: &I, block_radius: u32) -> GrayImage
 /// contains two classes of pixels which have distributions
 /// with equal variances. For details see:
 /// Xu, X., et al. Pattern recognition letters 32.7 (2011)
-pub fn otsu_level<I>(image: &I) -> u8
-    where I: GenericImage<Pixel = Luma<u8>>
-{
+pub fn otsu_level(image: &GrayImage) -> u8 {
     let hist = histogram(image);
     let levels = hist.len();
     let mut histc = [0i32; 256];
@@ -86,42 +82,27 @@ pub fn otsu_level<I>(image: &I) -> u8
 
 /// Returns a binarized image from an input 8bpp grayscale image
 /// obtained by applying the given threshold.
-pub fn threshold<I>(image: &I, thresh: u8) -> GrayImage
-    where I: GenericImage<Pixel = Luma<u8>>
-{
-    let mut out: GrayImage = ImageBuffer::new(image.width(), image.height());
-    out.copy_from(image, 0, 0);
+pub fn threshold(image: &GrayImage, thresh: u8) -> GrayImage {
+    let mut out = image.clone();
     threshold_mut(&mut out, thresh);
     out
 }
 
 /// Mutates given image to form a binarized version produced by applying
 /// the given threshold.
-pub fn threshold_mut<I>(image: &mut I, thresh: u8)
-    where I: GenericImage<Pixel = Luma<u8>>
-{
-    for y in 0..image.height() {
-        for x in 0..image.width() {
-            unsafe {
-                if image.unsafe_get_pixel(x, y)[0] as u8 <= thresh {
-                    image.unsafe_put_pixel(x, y, Luma([0]));
-                } else {
-                    image.unsafe_put_pixel(x, y, Luma([255]));
-                }
-            }
-        }
+pub fn threshold_mut(image: &mut GrayImage, thresh: u8) {
+    for p in image.iter_mut() {
+        *p = if *p <= thresh { 0 } else { 255 };
     }
 }
 
 /// Returns the histogram of grayscale values in an 8bpp
 /// grayscale image.
-pub fn histogram<I>(image: &I) -> [i32; 256]
-    where I: GenericImage<Pixel = Luma<u8>>
-{
+pub fn histogram(image: &GrayImage) -> [i32; 256] {
     let mut hist = [0i32; 256];
 
-    for pix in image.pixels() {
-        hist[pix.2[0] as usize] += 1;
+    for pix in image.iter() {
+        hist[*pix as usize] += 1;
     }
 
     hist
@@ -129,9 +110,7 @@ pub fn histogram<I>(image: &I) -> [i32; 256]
 
 /// Returns the cumulative histogram of grayscale values in an 8bpp
 /// grayscale image.
-pub fn cumulative_histogram<I>(image: &I) -> [i32; 256]
-    where I: GenericImage<Pixel = Luma<u8>>
-{
+pub fn cumulative_histogram(image: &GrayImage) -> [i32; 256] {
     let mut hist = histogram(image);
 
     for i in 1..hist.len() {
@@ -143,61 +122,40 @@ pub fn cumulative_histogram<I>(image: &I) -> [i32; 256]
 
 /// Equalises the histogram of an 8bpp grayscale image in place. See also
 /// [histogram equalization (wikipedia)](https://en.wikipedia.org/wiki/Histogram_equalization).
-pub fn equalize_histogram_mut<I>(image: &mut I)
-    where I: GenericImage<Pixel = Luma<u8>>
-{
+pub fn equalize_histogram_mut(image: &mut GrayImage) {
     let hist = cumulative_histogram(image);
     let total = hist[255] as f32;
 
-    for y in 0..image.height() {
-        for x in 0..image.width() {
-            let original = unsafe { image.unsafe_get_pixel(x, y)[0] as usize };
-            let fraction = hist[original] as f32 / total;
-            let out = f32::min(255f32, 255f32 * fraction);
-            unsafe { image.unsafe_put_pixel(x, y, Luma([out as u8])); }
-        }
+    for p in image.iter_mut() {
+        let fraction = hist[*p as usize] as f32 / total;
+        *p = (f32::min(255f32, 255f32 * fraction)) as u8;
     }
 }
 
 /// Equalises the histogram of an 8bpp grayscale image. See also
 /// [histogram equalization (wikipedia)](https://en.wikipedia.org/wiki/Histogram_equalization).
-pub fn equalize_histogram<I>(image: &I) -> GrayImage
-    where I: GenericImage<Pixel = Luma<u8>>
-{
-    let mut out: GrayImage = ImageBuffer::new(image.width(), image.height());
-    out.copy_from(image, 0, 0);
+pub fn equalize_histogram(image: &GrayImage) -> GrayImage {
+    let mut out = image.clone();
     equalize_histogram_mut(&mut out);
     out
 }
 
 /// Adjusts contrast of an 8bpp grayscale image in place so that its
 /// histogram is as close as possible to that of the target image.
-pub fn match_histogram_mut<I, J>(image: &mut I, target: &J)
-    where I : GenericImage<Pixel = Luma<u8>>,
-          J : GenericImage<Pixel = Luma<u8>>
-{
+pub fn match_histogram_mut(image: &mut GrayImage, target: &GrayImage) {
     let image_histc = cumulative_histogram(image);
     let target_histc = cumulative_histogram(target);
     let lut = histogram_lut(&image_histc, &target_histc);
 
-    for y in 0..image.height() {
-        for x in 0..image.width() {
-            unsafe {
-                let pix = image.unsafe_get_pixel(x, y)[0] as usize;
-                image.unsafe_put_pixel(x, y, Luma([lut[pix] as u8]));
-            }
-        }
+    for p in image.iter_mut() {
+        *p = lut[*p as usize] as u8;
     }
 }
 
 /// Adjusts contrast of an 8bpp grayscale image so that its
 /// histogram is as close as possible to that of the target image.
-pub fn match_histogram<I, J>(image: &I, target: &J) -> GrayImage
-    where I : GenericImage<Pixel = Luma<u8>>,
-          J : GenericImage<Pixel = Luma<u8>>
-{
-    let mut out: GrayImage = ImageBuffer::new(image.width(), image.height());
-    out.copy_from(image, 0, 0);
+pub fn match_histogram(image: &GrayImage, target: &GrayImage) -> GrayImage {
+    let mut out = image.clone();
     match_histogram_mut(&mut out, target);
     out
 }

--- a/src/corners.rs
+++ b/src/corners.rs
@@ -1,6 +1,7 @@
 //! Functions for detecting corners, also known as interest points.
 
 use image::{
+    GrayImage,
     GenericImage,
     Luma
 };
@@ -64,9 +65,7 @@ pub enum Fast {
 }
 
 /// Finds corners using FAST-12 features. See comment on Fast enum.
-pub fn corners_fast12<I>(image: &I, threshold: u8) -> Vec<Corner>
-    where I: GenericImage<Pixel=Luma<u8>> {
-
+pub fn corners_fast12(image: &GrayImage, threshold: u8) -> Vec<Corner> {
     let (width, height) = image.dimensions();
     let mut corners = vec![];
 
@@ -83,9 +82,7 @@ pub fn corners_fast12<I>(image: &I, threshold: u8) -> Vec<Corner>
 }
 
 /// Finds corners using FAST-9 features. See comment on Fast enum.
-pub fn corners_fast9<I>(image: &I, threshold: u8) -> Vec<Corner>
-    where I: GenericImage<Pixel=Luma<u8>> {
-
+pub fn corners_fast9(image: &GrayImage, threshold: u8) -> Vec<Corner> {
     let (width, height) = image.dimensions();
     let mut corners = vec![];
 
@@ -108,9 +105,7 @@ pub fn corners_fast9<I>(image: &I, threshold: u8) -> Vec<Corner>
 /// Note that the corner check uses a strict inequality, so if
 /// the smallest intensity difference between the center pixel
 /// and a corner pixel is n then the corner will have a score of n - 1.
-pub fn fast_corner_score<I>(image: &I, threshold: u8, x: u32, y: u32, variant: Fast) -> u8
-    where I: GenericImage<Pixel=Luma<u8>> {
-
+pub fn fast_corner_score(image: &GrayImage, threshold: u8, x: u32, y: u32, variant: Fast) -> u8 {
     let mut max = 255u8;
     let mut min = threshold;
 
@@ -149,9 +144,7 @@ pub fn fast_corner_score<I>(image: &I, threshold: u8, x: u32, y: u32, variant: F
 /// Checks if the given pixel is a corner according to the FAST9 detector.
 /// The current implementation is extremely inefficient.
 // TODO: Make this much faster!
-fn is_corner_fast9<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
-    where I: GenericImage<Pixel=Luma<u8>> {
-
+fn is_corner_fast9(image: &GrayImage, threshold: u8, x: u32, y: u32) -> bool {
     let (width, height) = image.dimensions();
     if x < 3 || y < 3 || x >= width - 3 || y >= height - 3 {
         return false;
@@ -189,9 +182,7 @@ fn is_corner_fast9<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
 }
 
 /// Checks if the given pixel is a corner according to the FAST12 detector.
-fn is_corner_fast12<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
-    where I: GenericImage<Pixel=Luma<u8>> {
-
+fn is_corner_fast12(image: &GrayImage, threshold: u8, x: u32, y: u32) -> bool {
     let (width, height) = image.dimensions();
     if x < 3 || y < 3 || x >= width - 3 || y >= height - 3 {
         return false;
@@ -240,10 +231,8 @@ fn is_corner_fast12<I>(image: &I, threshold: u8, x: u32, y: u32) -> bool
 }
 
 #[inline]
-unsafe fn get_circle<I>(image: &I, x: u32, y: u32,
-                        p0: i16, p4: i16, p8: i16, p12: i16) -> [i16; 16]
-    where I: GenericImage<Pixel=Luma<u8>>
-{
+unsafe fn get_circle(image: &GrayImage, x: u32, y: u32,
+                     p0: i16, p4: i16, p8: i16, p12: i16) -> [i16; 16] {
     [
         p0,
         image.unsafe_get_pixel(x + 1, y - 3)[0] as i16,
@@ -330,7 +319,6 @@ mod test {
         assert_eq!(is_corner_fast12(&image, 8, 3, 3), true);
     }
 
-
     #[test]
     fn test_is_corner_fast12_12_contiguous_darker_pixels_large_threshold() {
         let image: GrayImage = ImageBuffer::from_raw(7, 7, vec![
@@ -384,7 +372,7 @@ mod test {
             10, 00, 10, 10, 10, 10, 10,
             10, 10, 00, 00, 00, 10, 10]).unwrap();
 
-	b.iter(||is_corner_fast12(&image, 8, 3, 3));
+       b.iter(||is_corner_fast12(&image, 8, 3, 3));
     }
 
     #[test]

--- a/src/corners.rs
+++ b/src/corners.rs
@@ -2,8 +2,7 @@
 
 use image::{
     GrayImage,
-    GenericImage,
-    Luma
+    GenericImage
 };
 
 use definitions::{

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -12,12 +12,17 @@ use std::{
     i16
 };
 
-/// An `ImageBuffer` containing Pixels of type P with storage
-/// `Vec<P::Subpixel>`.
+/// An `ImageBuffer` containing Pixels of type P with storage `Vec<P::Subpixel>`.
+/// Most operations in this library only support inputs of type `Image`, rather
+/// than arbitrary `image::GenericImage`s. This is obviously less flexible, but
+/// has the advantage of allowing many functions to be more performant. We may want
+/// to add more flexibility later, but this should not be at the expense of performance.
+/// When specialisation lands we should be able to do this by defining traits for images
+/// with contiguous storage.
 // TODO: This produces a compiler warning about trait bounds
 // TODO: not being enforced in type definitions. In this case
 // TODO: they are. Can we get rid of the warning?
-pub type VecBuffer<P: Pixel> = ImageBuffer<P, Vec<P::Subpixel>>;
+pub type Image<P: Pixel> = ImageBuffer<P, Vec<P::Subpixel>>;
 
 /// Pixels which have a named Black value.
 pub trait HasBlack {

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -1,7 +1,7 @@
 //! Helpers for drawing basic shapes on images.
 
 use image::{GenericImage, ImageBuffer};
-use definitions::VecBuffer;
+use definitions::Image;
 use rect::Rect;
 use std::mem::swap;
 use std::cmp::{min, max};
@@ -40,7 +40,7 @@ pub fn draw_cross_mut<I>(image: &mut I, color: I::Pixel, x: i32, y: i32)
 }
 
 /// Draws a colored cross on an image. Handles coordinates outside image bounds.
-pub fn draw_cross<I>(image: &I, color: I::Pixel, x: i32, y: i32) -> VecBuffer<I::Pixel>
+pub fn draw_cross<I>(image: &I, color: I::Pixel, x: i32, y: i32) -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static
 {
@@ -56,7 +56,7 @@ pub fn draw_line_segment<I>(image: &I,
                             start: (f32, f32),
                             end: (f32, f32),
                             color: I::Pixel)
-                            -> VecBuffer<I::Pixel>
+                            -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static
 {
@@ -123,7 +123,7 @@ pub fn draw_antialiased_line_segment<I, B>(image: &I,
                                            end: (i32, i32),
                                            color: I::Pixel,
                                            blend: B)
-                                           -> VecBuffer<I::Pixel>
+                                           -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static,
           B: Fn(I::Pixel, I::Pixel, f32) -> I::Pixel
@@ -218,7 +218,7 @@ impl<'a, I, T, B> Plotter<'a, I, T, B>
 }
 
 /// Draws as much of the boundary of a rectangle as lies inside the image bounds.
-pub fn draw_hollow_rect<I>(image: &I, rect: Rect, color: I::Pixel) -> VecBuffer<I::Pixel>
+pub fn draw_hollow_rect<I>(image: &I, rect: Rect, color: I::Pixel) -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static
 {
@@ -245,7 +245,7 @@ pub fn draw_hollow_rect_mut<I>(image: &mut I, rect: Rect, color: I::Pixel)
 }
 
 /// Draw as much of a rectangle, including its boundary, as lies inside the image bounds.
-pub fn draw_filled_rect<I>(image: &I, rect: Rect, color: I::Pixel) -> VecBuffer<I::Pixel>
+pub fn draw_filled_rect<I>(image: &I, rect: Rect, color: I::Pixel) -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static
 {
@@ -282,7 +282,7 @@ pub fn draw_hollow_ellipse<I>(image: &I,
                               center: (i32, i32),
                               width_radius: i32,
                               height_radius: i32,
-                              color: I::Pixel) -> VecBuffer<I::Pixel>
+                              color: I::Pixel) -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static
 {
@@ -328,7 +328,7 @@ pub fn draw_filled_ellipse<I>(image: &I,
                               center: (i32, i32),
                               width_radius: i32,
                               height_radius: i32,
-                              color: I::Pixel) -> VecBuffer<I::Pixel>
+                              color: I::Pixel) -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static
 {
@@ -414,7 +414,7 @@ fn draw_ellipse<F>(mut render_func: F, center: (i32, i32), width_radius: i32, he
 pub fn draw_hollow_circle<I>(image: &I,
                              center: (i32, i32),
                              radius: i32,
-                             color: I::Pixel) -> VecBuffer<I::Pixel>
+                             color: I::Pixel) -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static
 {
@@ -484,7 +484,7 @@ pub fn draw_filled_circle_mut<I>(image: &mut I, center: (i32, i32), radius: i32,
 pub fn draw_filled_circle<I>(image: &I,
                              center: (i32, i32),
                              radius: i32,
-                             color: I::Pixel) -> VecBuffer<I::Pixel>
+                             color: I::Pixel) -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static
 {
@@ -524,7 +524,7 @@ impl<T: Copy + PartialEq + Eq> Point<T> {
 /// An implicit edge is added from the last to the first point in the slice.
 ///
 /// Does not validate that input is convex.
-pub fn draw_convex_polygon<I>(image: &I, poly: &[Point<i32>], color: I::Pixel) -> VecBuffer<I::Pixel>
+pub fn draw_convex_polygon<I>(image: &I, poly: &[Point<i32>], color: I::Pixel) -> Image<I::Pixel>
     where I : GenericImage, I::Pixel: 'static
 {
     let mut out = ImageBuffer::new(image.width(), image.height());
@@ -622,7 +622,7 @@ pub fn draw_convex_polygon_mut<I>(image: &mut I, poly: &[Point<i32>], color: I::
 }
 
 /// Draws as much of a cubic bezier curve as lies within image bounds.
-pub fn draw_cubic_bezier_curve<I>(image: &I, start: (f32, f32), end: (f32, f32), control_a: (f32, f32), control_b: (f32, f32), color: I::Pixel) -> VecBuffer<I::Pixel>
+pub fn draw_cubic_bezier_curve<I>(image: &I, start: (f32, f32), end: (f32, f32), control_a: (f32, f32), control_b: (f32, f32), color: I::Pixel) -> Image<I::Pixel>
     where I : GenericImage, I::Pixel: 'static
 {
     let mut out = ImageBuffer::new(image.width(), image.height());

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -1,7 +1,7 @@
 //! Functions for detecting edges in images.
 
 use std::f32;
-use image::{GenericImage, ImageBuffer, Luma};
+use image::{GenericImage, GrayImage, ImageBuffer, Luma};
 use gradients::{vertical_sobel, horizontal_sobel};
 use definitions::{HasWhite, HasBlack};
 use filter::gaussian_blur_f32;
@@ -18,12 +18,10 @@ use filter::gaussian_blur_f32;
 /// appear as edges in the output image.
 ///
 /// Returns a binary image, where edge pixels have a value of 255 and non-edge pixels a value of 0.
-pub fn canny<I>(image: &I,
-                low_threshold: f32,
-                high_threshold: f32)
-                -> ImageBuffer<Luma<u8>, Vec<u8>>
-    where I: GenericImage<Pixel = Luma<u8>> + 'static
-{
+pub fn canny(image: &GrayImage,
+             low_threshold: f32,
+             high_threshold: f32)
+             -> GrayImage {
     assert!(high_threshold >= low_threshold);
     // Heavily based on the implementation proposed by wikipedia.
     // 1. Gaussian blur.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,7 +1,7 @@
 //! Functions for filtering images.
-// TODO: unify with image::sample
 
 use image::{
+    GrayImage,
     GenericImage,
     ImageBuffer,
     Luma,
@@ -21,7 +21,7 @@ use map::{
 
 use definitions::{
     Clamp,
-    VecBuffer
+    Image
 };
 
 use num::{
@@ -43,11 +43,8 @@ use std::f32;
 // TODO: for small kernels we probably want to do the convolution
 // TODO: directly instead of using an integral image.
 // TODO: more formats!
-// TODO: number of operations is constant with kernel size,
-// TODO: but this is still _really_ slow. fix!
-pub fn box_filter<I>(image: &I, x_radius: u32, y_radius: u32)
-        -> VecBuffer<Luma<u8>>
-    where I: GenericImage<Pixel=Luma<u8>>{
+pub fn box_filter(image: &GrayImage, x_radius: u32, y_radius: u32)
+        -> Image<Luma<u8>> {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
@@ -109,14 +106,14 @@ impl<'a, K: Num + Copy + 'a> Kernel<'a, K> {
 
     /// Returns 2d correlation of an image. Intermediate calculations are performed
     /// at type K, and the results converted to pixel Q via f. Pads by continuity.
-    pub fn filter<I, F, Q>(&self, image: &I, mut f: F) -> VecBuffer<Q>
+    pub fn filter<I, F, Q>(&self, image: &I, mut f: F) -> Image<Q>
         where I: GenericImage,
               <I::Pixel as Pixel>::Subpixel: ValueInto<K>,
               Q: Pixel + 'static,
               F: FnMut(&mut Q::Subpixel, K) -> (),
     {
         let (width, height) = image.dimensions();
-        let mut out = VecBuffer::<Q>::new(width, height);
+        let mut out = Image::<Q>::new(width, height);
         let num_channels = I::Pixel::channel_count() as usize;
         let zero = K::zero();
         let mut acc = vec![zero; num_channels];
@@ -170,7 +167,7 @@ fn gaussian_kernel_f32(sigma: f32) -> Vec<f32> {
 /// The kernel used has type f32 and all intermediate calculations are performed
 /// at this type.
 // TODO: Integer type kernel, approximations via repeated box filter.
-pub fn gaussian_blur_f32<I>(image: &I, sigma: f32) -> VecBuffer<I::Pixel>
+pub fn gaussian_blur_f32<I>(image: &I, sigma: f32) -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<f32> + Clamp<f32>
@@ -182,7 +179,7 @@ pub fn gaussian_blur_f32<I>(image: &I, sigma: f32) -> VecBuffer<I::Pixel>
 /// Returns 2d correlation of view with the outer product of the 1d
 /// kernels `h_kernel` and `v_kernel`.
 pub fn separable_filter<I, K>(image: &I, h_kernel: &[K], v_kernel: &[K])
-        -> VecBuffer<I::Pixel>
+        -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K>,
@@ -195,7 +192,7 @@ pub fn separable_filter<I, K>(image: &I, h_kernel: &[K], v_kernel: &[K])
 /// Returns 2d correlation of an image with the outer product of the 1d
 /// kernel filter with itself.
 pub fn separable_filter_equal<I, K>(image: &I, kernel: &[K])
-        -> VecBuffer<I::Pixel>
+        -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K>,
@@ -205,7 +202,7 @@ pub fn separable_filter_equal<I, K>(image: &I, kernel: &[K])
 
 /// Returns 2d correlation of an image with a 3x3 row-major kernel. Intermediate calculations are
 /// performed at type K, and the results clamped to subpixel type S. Pads by continuity.
-pub fn filter3x3<I, P, K, S>(image: &I, kernel: &[K]) -> VecBuffer<ChannelMap<P, S>>
+pub fn filter3x3<I, P, K, S>(image: &I, kernel: &[K]) -> Image<ChannelMap<P, S>>
     where I: GenericImage<Pixel=P>,
           P::Subpixel: ValueInto<K>,
           S: Clamp<K> + Primitive + 'static,
@@ -219,7 +216,7 @@ pub fn filter3x3<I, P, K, S>(image: &I, kernel: &[K]) -> VecBuffer<ChannelMap<P,
 /// Pads by continuity. Intermediate calculations are performed at
 /// type K.
 pub fn horizontal_filter<I, K>(image: &I, kernel: &[K])
-        -> VecBuffer<I::Pixel>
+        -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K>,
@@ -232,7 +229,7 @@ pub fn horizontal_filter<I, K>(image: &I, kernel: &[K])
 ///	Returns horizontal correlations between an image and a 1d kernel.
 /// Pads by continuity.
 pub fn vertical_filter<I, K>(image: &I, kernel: &[K])
-        -> VecBuffer<I::Pixel>
+        -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<K> + Clamp<K>,
@@ -272,7 +269,7 @@ mod test {
         Luma,
         Rgb
     };
-    use definitions::VecBuffer;
+    use definitions::Image;
     use image::imageops::blur;
     use test;
 
@@ -446,7 +443,7 @@ mod test {
 
     /// Baseline implementation of Gaussian blur is that provided by image::imageops.
     /// We can also use this to validate correctnes of any implementations we add here.
-    fn gaussian_baseline_rgb<I>(image: &I, stdev: f32) -> VecBuffer<Rgb<u8>>
+    fn gaussian_baseline_rgb<I>(image: &I, stdev: f32) -> Image<Rgb<u8>>
         where I: GenericImage<Pixel=Rgb<u8>> + 'static
     {
         blur(image, stdev)

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -2,6 +2,7 @@
 
 use image::{
     GenericImage,
+    GrayImage,
     ImageBuffer,
     Luma
 };
@@ -28,17 +29,13 @@ static HORIZONTAL_SOBEL: [i32; 9] = [
 
 /// Convolves with the horizontal Sobel kernel to detect horizontal
 /// gradients in an image.
-pub fn horizontal_sobel<I>(image: &I) -> Image<Luma<i16>>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static
-{
+pub fn horizontal_sobel(image: &GrayImage) -> Image<Luma<i16>> {
     filter3x3(image, &HORIZONTAL_SOBEL)
 }
 
 /// Convolves with the vertical Sobel kernel to detect vertical
 /// gradients in an image.
-pub fn vertical_sobel<I>(image: &I) -> Image<Luma<i16>>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static
-{
+pub fn vertical_sobel(image: &GrayImage) -> Image<Luma<i16>> {
     filter3x3(image, &VERTICAL_SOBEL)
 }
 
@@ -56,31 +53,23 @@ static HORIZONTAL_PREWITT: [i32; 9] = [
 
 /// Convolves with the horizontal Prewitt kernel to detect horizontal
 /// gradients in an image.
-pub fn horizontal_prewitt<I>(image: &I) -> Image<Luma<i16>>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static
-{
+pub fn horizontal_prewitt(image: &GrayImage) -> Image<Luma<i16>> {
     filter3x3(image, &HORIZONTAL_PREWITT)
 }
 
 /// Convolves with the vertical Prewitt kernel to detect vertical
 /// gradients in an image.
-pub fn vertical_prewitt<I>(image: &I) -> Image<Luma<i16>>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static
-{
+pub fn vertical_prewitt(image: &GrayImage) -> Image<Luma<i16>> {
     filter3x3(image, &VERTICAL_PREWITT)
 }
 
 /// Returns the magnitudes of gradients in an image using Sobel filters.
-pub fn sobel_gradients<I>(image: &I) -> Image<Luma<u16>>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static
-{
+pub fn sobel_gradients(image: &GrayImage) -> Image<Luma<u16>> {
     gradients(image, &HORIZONTAL_SOBEL, &VERTICAL_SOBEL)
 }
 
 /// Returns the magnitudes of gradients in an image using Prewitt filters.
-pub fn prewitt_gradients<I>(image: &I) -> Image<Luma<u16>>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static
-{
+pub fn prewitt_gradients(image: &GrayImage) -> Image<Luma<u16>> {
     gradients(image, &HORIZONTAL_PREWITT, &VERTICAL_PREWITT)
 }
 
@@ -88,10 +77,8 @@ pub fn prewitt_gradients<I>(image: &I) -> Image<Luma<u16>>
 // TODO: Support filtering without allocating a fresh image - filtering functions could
 // TODO: take some kind of pixel-sink. This would allow us to compute gradient magnitudes
 // TODO: and directions without allocating intermediates for vertical and horizontal gradients.
-fn gradients<I>(image: &I, horizontal_kernel: &[i32; 9], vertical_kernel: &[i32; 9])
-    -> Image<Luma<u16>>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static
-{
+fn gradients(image: &GrayImage, horizontal_kernel: &[i32; 9], vertical_kernel: &[i32; 9])
+    -> Image<Luma<u16>> {
     let horizontal: ImageBuffer<Luma<i16>, Vec<i16>> = filter3x3(image, horizontal_kernel);
     let vertical: ImageBuffer<Luma<i16>, Vec<i16>> = filter3x3(image, vertical_kernel);
 

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -7,7 +7,7 @@ use image::{
 };
 
 use definitions::{
-    VecBuffer
+    Image
 };
 
 use filter::{
@@ -28,7 +28,7 @@ static HORIZONTAL_SOBEL: [i32; 9] = [
 
 /// Convolves with the horizontal Sobel kernel to detect horizontal
 /// gradients in an image.
-pub fn horizontal_sobel<I>(image: &I) -> VecBuffer<Luma<i16>>
+pub fn horizontal_sobel<I>(image: &I) -> Image<Luma<i16>>
     where I: GenericImage<Pixel=Luma<u8>> + 'static
 {
     filter3x3(image, &HORIZONTAL_SOBEL)
@@ -36,7 +36,7 @@ pub fn horizontal_sobel<I>(image: &I) -> VecBuffer<Luma<i16>>
 
 /// Convolves with the vertical Sobel kernel to detect vertical
 /// gradients in an image.
-pub fn vertical_sobel<I>(image: &I) -> VecBuffer<Luma<i16>>
+pub fn vertical_sobel<I>(image: &I) -> Image<Luma<i16>>
     where I: GenericImage<Pixel=Luma<u8>> + 'static
 {
     filter3x3(image, &VERTICAL_SOBEL)
@@ -56,7 +56,7 @@ static HORIZONTAL_PREWITT: [i32; 9] = [
 
 /// Convolves with the horizontal Prewitt kernel to detect horizontal
 /// gradients in an image.
-pub fn horizontal_prewitt<I>(image: &I) -> VecBuffer<Luma<i16>>
+pub fn horizontal_prewitt<I>(image: &I) -> Image<Luma<i16>>
     where I: GenericImage<Pixel=Luma<u8>> + 'static
 {
     filter3x3(image, &HORIZONTAL_PREWITT)
@@ -64,21 +64,21 @@ pub fn horizontal_prewitt<I>(image: &I) -> VecBuffer<Luma<i16>>
 
 /// Convolves with the vertical Prewitt kernel to detect vertical
 /// gradients in an image.
-pub fn vertical_prewitt<I>(image: &I) -> VecBuffer<Luma<i16>>
+pub fn vertical_prewitt<I>(image: &I) -> Image<Luma<i16>>
     where I: GenericImage<Pixel=Luma<u8>> + 'static
 {
     filter3x3(image, &VERTICAL_PREWITT)
 }
 
 /// Returns the magnitudes of gradients in an image using Sobel filters.
-pub fn sobel_gradients<I>(image: &I) -> VecBuffer<Luma<u16>>
+pub fn sobel_gradients<I>(image: &I) -> Image<Luma<u16>>
     where I: GenericImage<Pixel=Luma<u8>> + 'static
 {
     gradients(image, &HORIZONTAL_SOBEL, &VERTICAL_SOBEL)
 }
 
 /// Returns the magnitudes of gradients in an image using Prewitt filters.
-pub fn prewitt_gradients<I>(image: &I) -> VecBuffer<Luma<u16>>
+pub fn prewitt_gradients<I>(image: &I) -> Image<Luma<u16>>
     where I: GenericImage<Pixel=Luma<u8>> + 'static
 {
     gradients(image, &HORIZONTAL_PREWITT, &VERTICAL_PREWITT)
@@ -89,7 +89,7 @@ pub fn prewitt_gradients<I>(image: &I) -> VecBuffer<Luma<u16>>
 // TODO: take some kind of pixel-sink. This would allow us to compute gradient magnitudes
 // TODO: and directions without allocating intermediates for vertical and horizontal gradients.
 fn gradients<I>(image: &I, horizontal_kernel: &[i32; 9], vertical_kernel: &[i32; 9])
-    -> VecBuffer<Luma<u16>>
+    -> Image<Luma<u16>>
     where I: GenericImage<Pixel=Luma<u8>> + 'static
 {
     let horizontal: ImageBuffer<Luma<i16>, Vec<i16>> = filter3x3(image, horizontal_kernel);

--- a/src/haar.rs
+++ b/src/haar.rs
@@ -1,6 +1,6 @@
 //! Functions for creating and evaluating [Haar-like features](https://en.wikipedia.org/wiki/Haar-like_features).
 
-use definitions::{HasBlack,HasWhite,VecBuffer};
+use definitions::{HasBlack,HasWhite,Image};
 use image::{GenericImage,ImageBuffer,Luma};
 use itertools::Itertools;
 use std::collections::HashMap;
@@ -318,7 +318,7 @@ fn multiplier(sign: Sign) -> i8 {
 
 /// Draws the given Haar filter on an image, drawing pixels
 /// with a positive sign white and those with a negative sign black.
-pub fn draw_haar_filter<I>(image: &I, filter: HaarFilter) -> VecBuffer<I::Pixel>
+pub fn draw_haar_filter<I>(image: &I, filter: HaarFilter) -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: HasBlack + HasWhite + 'static
 {

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -3,6 +3,7 @@
 
 use image::{
 	GenericImage,
+	GrayImage,
 	ImageBuffer,
 	Luma
 };
@@ -169,9 +170,7 @@ fn num_blocks(num_cells: usize, block_side: usize, block_stride: usize) -> usize
 /// Computes the HoG descriptor of an image, or None if the provided
 /// options are incompatible with the image size.
 // TODO: support color images by taking the channel with maximum gradient at each point
-pub fn hog<I>(image: &I, options: HogOptions) -> Result<Vec<f32>, String>
-	where I: GenericImage<Pixel=Luma<u8>> + 'static
-{
+pub fn hog(image: &GrayImage, options: HogOptions) -> Result<Vec<f32>, String> {
 	match HogSpec::from_options(image.width(), image.height(), options) {
 		Err(e) => Err(e),
 		Ok(spec) => {
@@ -240,9 +239,7 @@ fn copy<T: Copy>(from: &[T], to: &mut[T]) {
 
 /// Computes orientation histograms for each cell of an image. Assumes that
 /// the provided dimensions are valid.
-pub fn cell_histograms<I>(image: &I, spec: HogSpec) -> Array3d<f32>
-    where I: GenericImage<Pixel=Luma<u8>> + 'static {
-
+pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let (width, height) = image.dimensions();
 	let mut grid = Array3d::new(spec.cell_grid_lengths());
 	let cell_area = spec.cell_area() as f32;

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -16,7 +16,7 @@ use multiarray::{
 };
 use definitions::{
 	Clamp,
-	VecBuffer
+	Image
 };
 use math::l2_norm;
 use std::f32;
@@ -352,7 +352,7 @@ impl Interpolation {
 /// Note that we ignore block-level aggregation or normalisation here.
 /// Each rendered star has side length `star_side`, so the image will have
 /// width grid.lengths[1] * `star_side` and height grid.lengths[2] * `star_side`.
-pub fn render_hist_grid(star_side: u32, grid: &View3d<f32>, signed: bool) -> VecBuffer<Luma<u8>> {
+pub fn render_hist_grid(star_side: u32, grid: &View3d<f32>, signed: bool) -> Image<Luma<u8>> {
 	let width = grid.lengths[1] as u32 * star_side;
 	let height = grid.lengths[2] as u32 * star_side;
 	let mut out = ImageBuffer::new(width, height);

--- a/src/map.rs
+++ b/src/map.rs
@@ -11,7 +11,7 @@ use image::{
 };
 
 use definitions::{
-    VecBuffer
+    Image
 };
 
 /// The type obtained by replacing the channel type of a given Pixel type.
@@ -42,7 +42,7 @@ impl<T, U> WithChannel<U> for Luma<T>
 }
 
 /// Applies f to each subpixel of the input image.
-pub fn map_subpixels<I, P, F, S>(image: &I, f: F) -> VecBuffer<ChannelMap<P, S>>
+pub fn map_subpixels<I, P, F, S>(image: &I, f: F) -> Image<ChannelMap<P, S>>
     where I: GenericImage<Pixel=P>,
           P: WithChannel<S> + 'static,
           S: Primitive + 'static,
@@ -66,7 +66,7 @@ pub fn map_subpixels<I, P, F, S>(image: &I, f: F) -> VecBuffer<ChannelMap<P, S>>
 }
 
 /// Applies f to the color of each pixel in the input image.
-pub fn map_colors<I, P, Q, F>(image: &I, f: F) -> VecBuffer<Q>
+pub fn map_colors<I, P, Q, F>(image: &I, f: F) -> Image<Q>
     where I: GenericImage<Pixel=P>,
           P: Pixel,
           Q: Pixel + 'static,
@@ -88,7 +88,7 @@ pub fn map_colors<I, P, Q, F>(image: &I, f: F) -> VecBuffer<Q>
 }
 
 /// Applies f to each pixel in the input image.
-pub fn map_pixels<I, P, Q, F>(image: &I, f: F) -> VecBuffer<Q>
+pub fn map_pixels<I, P, Q, F>(image: &I, f: F) -> Image<Q>
     where I: GenericImage<Pixel=P>,
           P: Pixel,
           Q: Pixel + 'static,
@@ -112,7 +112,7 @@ pub fn map_pixels<I, P, Q, F>(image: &I, f: F) -> VecBuffer<Q>
 macro_rules! implement_channel_extraction {
     ($extract_name: ident, $embed_name: ident, $idx: expr) => (
         /// Create a grayscale image by extracting a channel of an RGB image.
-        pub fn $extract_name<I, C>(image: &I) -> VecBuffer<Luma<C>>
+        pub fn $extract_name<I, C>(image: &I) -> Image<Luma<C>>
             where I: GenericImage<Pixel=Rgb<C>>,
                   C: Primitive + 'static
         {
@@ -120,7 +120,7 @@ macro_rules! implement_channel_extraction {
         }
 
         /// Create an RGB image by embedding a grayscale image in a single channel.
-        pub fn $embed_name<I, C>(image: &I) -> VecBuffer<Rgb<C>>
+        pub fn $embed_name<I, C>(image: &I) -> Image<Rgb<C>>
             where I: GenericImage<Pixel=Luma<C>>,
                   C: Primitive + 'static
         {

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -21,7 +21,7 @@ use definitions::{
     Clamp,
     HasBlack,
     HasWhite,
-    VecBuffer
+    Image
 };
 
 use conv::{
@@ -35,7 +35,7 @@ use math::{
 /// Adds independent additive Gaussian noise to all channels
 /// of an image, with the given mean and standard deviation.
 pub fn gaussian_noise<I>(image: &I, mean: f64, stddev: f64, seed: usize)
-        -> VecBuffer<I::Pixel>
+        -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: ValueInto<f64> + Clamp<f64> {
@@ -77,7 +77,7 @@ pub fn gaussian_noise_mut<I>(image: &mut I, mean: f64, stddev: f64, seed: usize)
 /// Converts pixels to black or white at the given `rate` (between 0.0 and 1.0).
 /// Black and white occur with equal probability.
 pub fn salt_and_pepper_noise<I>(image: &I, rate: f64, seed: usize)
-        -> VecBuffer<I::Pixel>
+        -> Image<I::Pixel>
     where I: GenericImage, I::Pixel: HasBlack + HasWhite + 'static {
 
     let mut out = ImageBuffer::new(image.width(), image.height());

--- a/src/regionlabelling.rs
+++ b/src/regionlabelling.rs
@@ -7,7 +7,7 @@ use image::{
 };
 
 use definitions::{
-    VecBuffer
+    Image
 };
 
 use unionfind::{
@@ -32,7 +32,7 @@ pub enum Connectivity {
 /// is labelled by the connected foreground component it belongs to,
 /// or 0 if it's in the background. Input pixels are treated as belonging
 /// to the background if and only if they are equal to the provided background pixel.
-pub fn connected_components<I>(image: &I, conn: Connectivity, background: I::Pixel) -> VecBuffer<Luma<u32>>
+pub fn connected_components<I>(image: &I, conn: Connectivity, background: I::Pixel) -> Image<Luma<u32>>
     where I: GenericImage,
           I::Pixel: Eq
 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 //! Utils for testing and debugging.
 
-use definitions::VecBuffer;
+use definitions::Image;
 
 use image::{
     DynamicImage,
@@ -200,7 +200,7 @@ pub fn rgb_bench_image(width: u32, height: u32) -> RgbImage {
 
 /// Wrapper for image buffers to allow us to write an Arbitrary instance.
 #[derive(Clone)]
-pub struct TestBuffer<T: Pixel>(pub VecBuffer<T>);
+pub struct TestBuffer<T: Pixel>(pub Image<T>);
 
 /// 8bpp grayscale `TestBuffer`.
 pub type GrayTestImage = TestBuffer<Luma<u8>>;
@@ -235,7 +235,7 @@ pub trait ArbitraryPixel {
     fn arbitrary<G: Gen>(g: &mut G) -> Self;
 }
 
-fn shrink<I>(image: &I) -> Box<Iterator<Item=VecBuffer<I::Pixel>>>
+fn shrink<I>(image: &I) -> Box<Iterator<Item=Image<I::Pixel>>>
     where I: GenericImage,
           I::Pixel: 'static
 {
@@ -260,7 +260,7 @@ fn shrink<I>(image: &I) -> Box<Iterator<Item=VecBuffer<I::Pixel>>>
     Box::new(subs.into_iter())
 }
 
-fn copy_sub<I>(image: &I, x: u32, y: u32, width: u32, height: u32) -> VecBuffer<I::Pixel>
+fn copy_sub<I>(image: &I, x: u32, y: u32, width: u32, height: u32) -> Image<I::Pixel>
     where I: GenericImage,
           I::Pixel: 'static
 {


### PR DESCRIPTION
This is a breaking change - all the affected methods can now be applied to fewer image types. Reverse crate dependencies on crates.io suggests that only one other crate depends on this one, and that is already use ImageBuffer, so we shouldn't be breaking anyone's code.

The change gives a large speedup on the functions in the contrast module, but has surprisingly little effect elsewhere.

@tafia experiemented with switching some of the histogram methods over on the performance branch a while ago, but I held off on merging them because I didn't want to restrict the set of types we supported (and also hoped that some day we might do something clever with lazy images).

However, in practise I think most people will already be using ImageBuffers anyway, and we can get some concrete performance improvements now by making this change. When we have implementations that we're happy are reasonably performant (which is definitely not the case now for most of the functions) then we can think about what properties of ImageBuffer we actually rely on, and write some traits specifying those. When specialisation lands we can re-add the more general functions if necessary, by providing a generic version and a specialised faster version of each function.

Benchmark diffs below. There's a lot of noise in these - several functions aren't touched at all by these changes and still vary by up to 10% in either direction.
```
 name                                                                before.txt ns/iter  after.txt ns/iter  diff ns/iter   diff % 
 affine::test::bench_affine_bilinear                                 709,231             711,130                   1,899    0.27% 
 affine::test::bench_affine_nearest                                  379,976             381,071                   1,095    0.29% 
 affine::test::bench_rotate_bilinear                                 403,804             439,796                  35,992    8.91% 
 affine::test::bench_rotate_nearest                                  321,725             321,523                    -202   -0.06% 
 affine::test::bench_translate                                       262,690             252,569                 -10,121   -3.85% 
 contrast::test::bench_adaptive_threshold                            420,006             461,051                  41,045    9.77% 
 contrast::test::bench_equalize_histogram                            2,066,377           998,591              -1,067,786  -51.67% 
 contrast::test::bench_equalize_histogram_mut                        1,498,665           976,207                -522,458  -34.86% 
 contrast::test::bench_match_histogram                               227,486             104,518                -122,968  -54.06% 
 contrast::test::bench_match_histogram_mut                           189,572             139,958                 -49,614  -26.17% 
 contrast::test::bench_otsu_level                                    87,487              23,529                  -63,958  -73.11% 
 contrast::test::bench_threshold                                     846,889             24,829                 -822,060  -97.07% 
 contrast::test::bench_threshold_mut                                 283,270             7,554                  -275,716  -97.33% 
 corners::test::bench_is_corner_fast12_12_noncontiguous              21                  23                            2    9.52% 
 corners::test::bench_is_corner_fast9_9_contiguous_lighter_pixels    21                  23                            2    9.52% 
 drawing::test::bench_bench_filled_ellipse_circle                    41,472              41,072                     -400   -0.96% 
 drawing::test::bench_bench_filled_ellipse_horizontal                42,813              43,865                    1,052    2.46% 
 drawing::test::bench_bench_filled_ellipse_vertical                  25,170              25,802                      632    2.51% 
 drawing::test::bench_bench_hollow_ellipse_circle                    503                 511                           8    1.59% 
 drawing::test::bench_bench_hollow_ellipse_horizontal                1,022               1,076                        54    5.28% 
 drawing::test::bench_bench_hollow_ellipse_vertical                  1,029               1,089                        60    5.83% 
 drawing::test::bench_draw_antialiased_line_segment_diagonal         3,358               3,546                       188    5.60% 
 drawing::test::bench_draw_antialiased_line_segment_horizontal       3,301               3,740                       439   13.30% 
 drawing::test::bench_draw_antialiased_line_segment_shallow          3,497               3,547                        50    1.43% 
 drawing::test::bench_draw_antialiased_line_segment_vertical         2,864               3,133                       269    9.39% 
 drawing::test::bench_draw_cubic_bezier_curve_long                   7,100               7,847                       747   10.52% 
 drawing::test::bench_draw_cubic_bezier_curve_short                  308                 310                           2    0.65% 
 drawing::test::bench_draw_filled_rect_mut_rgb                       6,019               6,525                       506    8.41% 
 edges::test::bench_canny                                            3,800,942           3,820,725                19,783    0.52% 
 filter::test::bench_box_filter                                      2,629,008           2,943,751               314,743   11.97% 
 filter::test::bench_filter3x3_i32_filter                            1,969,125           2,224,585               255,460   12.97% 
 filter::test::bench_gaussian_f32_stdev_1                            451,388             444,995                  -6,393   -1.42% 
 filter::test::bench_gaussian_f32_stdev_10                           3,029,111           3,017,772               -11,339   -0.37% 
 filter::test::bench_gaussian_f32_stdev_3                            1,024,038           998,875                 -25,163   -2.46% 
 filter::test::bench_horizontal_filter                               2,228,436           2,240,365                11,929    0.54% 
 filter::test::bench_separable_filter                                1,892,253           1,848,014               -44,239   -2.34% 
 filter::test::bench_vertical_filter                                 3,017,736           2,974,406               -43,330   -1.44% 
 haar::test::bench_evaluate_all_filters_10x10                        2,207,537           2,190,063               -17,474   -0.79% 
 hog::test::bench_hog                                                414,377             405,809                  -8,568   -2.07% 
 integralimage::test::bench_column_running_sum                       714                 750                          36    5.04% 
 integralimage::test::bench_integral_image                           492,229             482,435                  -9,794   -1.99% 
 integralimage::test::bench_row_running_sum                          535                 584                          49    9.16% 
 localbinarypatterns::test::bench_local_binary_pattern               3,664               3,681                        17    0.46% 
 noise::test::bench_gaussian_noise_mut                               137,303             136,493                    -810   -0.59% 
 noise::test::bench_salt_and_pepper_noise_mut                        113,265             104,840                  -8,425   -7.44% 
 pixelops::test::bench_interpolate_gray                              2                   2                             0    0.00% 
 pixelops::test::bench_interpolate_rgb                               6                   6                             0    0.00% 
 pixelops::test::bench_weighted_sum_gray                             2                   2                             0    0.00% 
 pixelops::test::bench_weighted_sum_rgb                              6                   6                             0    0.00% 
 regionlabelling::test::bench_connected_components_eight_chessboard  1,116,054           1,102,163               -13,891   -1.24% 
 regionlabelling::test::bench_connected_components_four_chessboard   562,800             547,714                 -15,086   -2.68% 
 stats::test::bench_root_mean_squared_error_gray                     45,141              44,363                     -778   -1.72% 
 stats::test::bench_root_mean_squared_error_rgb                      14,396              14,040                     -356   -2.47% 
 suppress::test::bench_local_maxima_dense                            28,060              31,321                    3,261   11.62% 
 suppress::test::bench_local_maxima_sparse                           34,023              34,012                      -11   -0.03% 
 suppress::test::bench_suppress_non_maximum_decreasing_gradient      1,202               1,173                       -29   -2.41% 
 suppress::test::bench_suppress_non_maximum_increasing_gradient      1,547               1,727                       180   11.64% 
 suppress::test::bench_suppress_non_maximum_noise_1                  4,779               5,450                       671   14.04% 
 suppress::test::bench_suppress_non_maximum_noise_3                  2,837               3,013                       176    6.20% 
 suppress::test::bench_suppress_non_maximum_noise_7                  2,090               2,067                       -23   -1.10% 
 unionfind::test::bench_disjoint_set_forest                          288,237             281,173                  -7,064   -2.45% 
```