### PR TITLE
Use rayon to parallelise equalize_histogram

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ nalgebra = "0.5.1"
 num = "0.1.27"
 quickcheck = "0.2.24"
 rand = "0.3.11"
+rayon = "0.6.0"
 
 [profile.release]
 opt-level = 3

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -94,7 +94,7 @@ pub fn threshold(image: &GrayImage, thresh: u8) -> GrayImage {
 pub fn threshold_mut(image: &mut GrayImage, thresh: u8) {
     for p in image.iter_mut() {
         *p = if *p <= thresh { 0 } else { 255 };
-    };
+    }
 }
 
 /// Returns the histogram of grayscale values in an 8bpp
@@ -150,7 +150,7 @@ pub fn match_histogram_mut(image: &mut GrayImage, target: &GrayImage) {
 
     for p in image.iter_mut() {
         *p = lut[*p as usize] as u8;
-    };
+    }
 }
 
 /// Adjusts contrast of an 8bpp grayscale image so that its

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -128,7 +128,7 @@ pub fn equalize_histogram_mut(image: &mut GrayImage) {
     let total = hist[255] as f32;
 
     image.par_iter_mut().for_each(|p| {
-        let fraction = hist[*p as usize] as f32 / total;
+        let fraction = unsafe { *hist.get_unchecked(*p as usize) as f32 / total };
         *p = (f32::min(255f32, 255f32 * fraction)) as u8;
     });
 }

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -4,6 +4,7 @@ use std::cmp::{min, max};
 use image::{GrayImage, ImageBuffer, Luma};
 use definitions::{HasBlack, HasWhite};
 use integralimage::{integral_image, sum_image_pixels};
+use rayon::prelude::*;
 
 /// Applies an adaptive threshold to an image.
 ///
@@ -93,7 +94,7 @@ pub fn threshold(image: &GrayImage, thresh: u8) -> GrayImage {
 pub fn threshold_mut(image: &mut GrayImage, thresh: u8) {
     for p in image.iter_mut() {
         *p = if *p <= thresh { 0 } else { 255 };
-    }
+    };
 }
 
 /// Returns the histogram of grayscale values in an 8bpp
@@ -126,10 +127,10 @@ pub fn equalize_histogram_mut(image: &mut GrayImage) {
     let hist = cumulative_histogram(image);
     let total = hist[255] as f32;
 
-    for p in image.iter_mut() {
+    image.par_iter_mut().for_each(|p| {
         let fraction = hist[*p as usize] as f32 / total;
         *p = (f32::min(255f32, 255f32 * fraction)) as u8;
-    }
+    });
 }
 
 /// Equalises the histogram of an 8bpp grayscale image. See also
@@ -149,7 +150,7 @@ pub fn match_histogram_mut(image: &mut GrayImage, target: &GrayImage) {
 
     for p in image.iter_mut() {
         *p = lut[*p as usize] as u8;
-    }
+    };
 }
 
 /// Adjusts contrast of an 8bpp grayscale image so that its

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate nalgebra;
 extern crate num;
 extern crate quickcheck;
 extern crate rand;
+extern crate rayon;
 
 #[macro_use]
 pub mod utils;


### PR DESCRIPTION
```
 name                                          before.txt ns/iter  after.txt ns/iter  diff ns/iter   diff % 
 contrast::test::bench_equalize_histogram      890,457             401,896                -488,561  -54.87% 
 contrast::test::bench_equalize_histogram_mut  871,876             386,931                -484,945  -55.62% 
```