### PR TITLE
Check if font coordinates are postive values before assigning to u32

### DIFF
--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -31,13 +31,15 @@ pub fn draw_text_mut<I>(image: &mut I, color: I::Pixel, x: u32, y: u32, scale: S
                 let gx = gx as i32 + bb.min.x;
                 let gy = gy as i32 + bb.min.y;
 
-                let image_x = gx as u32 + x;
-                let image_y = gy as u32 + y;
+                if gx >= 0 && gy >= 0 {
+                  let image_x = gx as u32 + x;
+                  let image_y = gy as u32 + y;
 
-                if image_x >= 0 && image_x < image.width() && image_y >= 0 && image_y < image.height() {
-                    let pixel = image.get_pixel(image_x, image_y);
-                    let weighted_color = weighted_sum(pixel, color, 1.0 - gv, gv);
-                    image.put_pixel(image_x, image_y, weighted_color);
+                  if image_x >= 0 && image_x < image.width() && image_y >= 0 && image_y < image.height() {
+                      let pixel = image.get_pixel(image_x, image_y);
+                      let weighted_color = weighted_sum(pixel, color, 1.0 - gv, gv);
+                      image.put_pixel(image_x, image_y, weighted_color);
+                  }
                 }
             })
         }

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -31,15 +31,16 @@ pub fn draw_text_mut<I>(image: &mut I, color: I::Pixel, x: u32, y: u32, scale: S
                 let gx = gx as i32 + bb.min.x;
                 let gy = gy as i32 + bb.min.y;
 
-                if gx >= 0 && gy >= 0 {
-                    let image_x = gx as u32 + x;
-                    let image_y = gy as u32 + y;
+                let image_x = gx + x as i32;
+                let image_y = gy + y as i32;
 
-                    if image_x >= 0 && image_x < image.width() && image_y >= 0 && image_y < image.height() {
-                        let pixel = image.get_pixel(image_x, image_y);
-                        let weighted_color = weighted_sum(pixel, color, 1.0 - gv, gv);
-                        image.put_pixel(image_x, image_y, weighted_color);
-                    }
+                let image_width = image.width() as i32;
+                let image_height = image.height() as i32;
+
+                if image_x >= 0 && image_x < image_width && image_y >= 0 && image_y < image_height {
+                    let pixel = image.get_pixel(image_x as u32, image_y as u32);
+                    let weighted_color = weighted_sum(pixel, color, 1.0 - gv, gv);
+                    image.put_pixel(image_x as u32, image_y as u32, weighted_color);
                 }
             })
         }

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -32,14 +32,14 @@ pub fn draw_text_mut<I>(image: &mut I, color: I::Pixel, x: u32, y: u32, scale: S
                 let gy = gy as i32 + bb.min.y;
 
                 if gx >= 0 && gy >= 0 {
-                  let image_x = gx as u32 + x;
-                  let image_y = gy as u32 + y;
+                    let image_x = gx as u32 + x;
+                    let image_y = gy as u32 + y;
 
-                  if image_x >= 0 && image_x < image.width() && image_y >= 0 && image_y < image.height() {
-                      let pixel = image.get_pixel(image_x, image_y);
-                      let weighted_color = weighted_sum(pixel, color, 1.0 - gv, gv);
-                      image.put_pixel(image_x, image_y, weighted_color);
-                  }
+                    if image_x >= 0 && image_x < image.width() && image_y >= 0 && image_y < image.height() {
+                        let pixel = image.get_pixel(image_x, image_y);
+                        let weighted_color = weighted_sum(pixel, color, 1.0 - gv, gv);
+                        image.put_pixel(image_x, image_y, weighted_color);
+                    }
                 }
             })
         }


### PR DESCRIPTION
There are cases where `gx` or `gy` have the value `-1`, before they are cast to u32. This results in the following stacktrace:

```
thread 'main' panicked at 'attempt to add with overflow', /Users/atlas/.cargo/registry/src/github.com-1ecc6299db9ec823/imageproc-0.8.0/src/drawing.rs:34
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
   1: std::panicking::default_hook::{{closure}}
   2: std::panicking::default_hook
   3: std::panicking::rust_panic_with_hook
   4: std::panicking::begin_panic
   5: std::panicking::begin_panic_fmt
   6: rust_begin_unwind
   7: core::panicking::panic_fmt
   8: core::panicking::panic
   9: imageproc::drawing::draw_text_mut::{{closure}}
  10: rusttype::rasterizer::rasterize
  11: rusttype::PositionedGlyph::draw
  12: imageproc::drawing::draw_text_mut
  13: good_morning::buildimg::text_to_image
  14: good_morning::main
  15: std::panicking::try::do_call
  16: __rust_maybe_catch_panic
  17: std::rt::lang_start
  18: main
```

I encounter this with a script that very closely copies the `examples/drawing.rs`, but with a loop that adds [line break offsets](https://github.com/at1as/good_morning/blob/master/src/buildimg.rs#L26).

If I add the following print statement to [line 30](https://github.com/PistonDevelopers/imageproc/blob/master/src/drawing.rs#L30) I can see that gx will become negative on line 31.

```
println!("GX={} // GY={} // GV={} // BB.MIN.X={} // BB.MIN.Y={} // X={}", gx, gy, gv, bb.min.x, bb.min.y, x, y);

=> "GX=0 // GY=0 // GV=0 // BB.MIN.X=-1 // BB.MIN.Y=4 // X=10 // Y=300"
```

The logic around this seemed to have changed around [this commit](https://github.com/PistonDevelopers/imageproc/pull/157/files/3ce0d47b0446fb064855f71ec463afa29980e3cb..736920b68eb1d6c19e7626f058e9310e9c23c285)


I'm quite new to rust, so I wasn't very effective at figuring out exactly why this is happening, or if this is the correct approach. But for what it's worth, this fixed the issues I was having (and the output image isn't missing any of the characters that I pass the `draw_text_mut` function).
