### PR TITLE
remove HasBlack trait bound for rotate_with_default

### DIFF
--- a/src/affine.rs
+++ b/src/affine.rs
@@ -125,7 +125,7 @@ pub fn rotate_with_default<P>(
     interpolation: Interpolation,
 ) -> Image<P>
 where
-    P: Pixel + HasBlack + 'static,
+    P: Pixel + 'static,
     <P as Pixel>::Subpixel: ValueInto<f32> + Clamp<f32>,
 {
     match interpolation {


### PR DESCRIPTION
Addresses #214. Removes the trait bound requiring an image's `Pixel` type to implement `HasBlack` when rotating with `rotate_with_default` (which doesn't utilize the trait whatsoever).