### PR TITLE
Add match_template

### DIFF
--- a/examples/template_matching.rs
+++ b/examples/template_matching.rs
@@ -1,0 +1,107 @@
+//! An example of template matching in a greyscale image.
+//! If running from the root directory of this crate you can test on the
+//! wrench image in /examples by running
+//! `cargo run --example template_matching ./examples/wrench.jpg ./tmp`
+extern crate image;
+extern crate imageproc;
+
+use std::env;
+use std::path::Path;
+use std::fs;
+use std::f32;
+use image::{open, GenericImage, GrayImage, Luma, Rgb};
+use imageproc::definitions::Image;
+use imageproc::template_matching::match_template;
+use imageproc::map::map_colors;
+use imageproc::rect::Rect;
+use imageproc::drawing::draw_hollow_rect_mut;
+
+/// Convert an f32-valued image to a 8 bit depth, covering the whole
+/// available intensity range.
+fn convert_to_gray_image(image: &Image<Luma<f32>>) -> GrayImage {
+    let mut lo = f32::INFINITY;
+    let mut hi = f32::NEG_INFINITY;
+
+    for p in image.iter() {
+        lo = if *p < lo { *p } else { lo };
+        hi = if *p > hi { *p } else { hi };
+    }
+
+    let range = hi - lo;
+    let scale = |x| (255.0 * (x - lo) / range) as u8;
+    map_colors(image, |p| {
+        Luma([scale(p[0])])
+    })
+}
+
+fn copy_sub_image(image: &GrayImage, x: u32, y: u32, w: u32, h: u32) -> GrayImage {
+    assert!(x + w < image.width() && y + h < image.height(), "invalid sub-image");
+
+    let mut result = GrayImage::new(w, h);
+    for sy in 0..h {
+        for sx in 0..w {
+            result.put_pixel(sx, sy, *image.get_pixel(x + sx, y + sy));
+        }
+    }
+
+    result
+}
+
+fn main() {
+    if env::args().len() != 3 {
+        panic!("Please enter an input file and a target directory")
+    }
+
+    let input_path = env::args().nth(1).unwrap();
+    let output_dir = env::args().nth(2).unwrap();
+
+    let input_path = Path::new(&input_path);
+    let output_dir = Path::new(&output_dir);
+
+    if !output_dir.is_dir() {
+        fs::create_dir(output_dir).expect("Failed to create output directory")
+    }
+
+    if !input_path.is_file() {
+        panic!("Input file does not exist");
+    }
+
+    // Load image and convert to grayscale
+    let image = open(input_path)
+        .expect(&format!("Could not load image at {:?}", input_path))
+        .to_luma();
+
+    // Save grayscale image in output directory
+    let gray_path = output_dir.join("image.png");
+    image.save(&gray_path).unwrap();
+
+    // Crop a section of the input image as the template
+    // This will fail if the input image is too small...
+    let template_width = 25;
+    let template_height = 25;
+    let template_x = 157;
+    let template_y = 85;
+    let template = copy_sub_image(&image, template_x, template_y, template_width, template_height);
+    let template_path = output_dir.join("template.png");
+    template.save(&template_path).unwrap();
+
+    // Match the template and convert to u8 depth to display
+    let result = match_template(&image, &template);
+    let result_scaled = convert_to_gray_image(&result);
+
+    // Pad the result to the same size as the input image, to make
+    // it easier to compare the two
+    let mut result_padded = GrayImage::new(image.width(), image.height());
+    result_padded.copy_from(&result_scaled, template_width / 2, template_height / 2);
+
+    // Show location the template was extracted from
+    let mut result_padded = map_colors(&result_padded, |p| Rgb([p[0], p[0], p[0]]));
+    draw_hollow_rect_mut(
+        &mut result_padded,
+        Rect::at(template_x as i32, template_y as i32)
+            .of_size(template_width, template_height),
+        Rgb([0, 255, 0]));
+
+    let result_path = output_dir.join("result.png");
+    result_padded.save(&result_path).unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,4 +42,5 @@ pub mod region_labelling;
 pub mod seam_carving;
 pub mod stats;
 pub mod suppress;
+pub mod template_matching;
 pub mod union_find;

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -28,7 +28,8 @@ pub fn match_template(image: &GrayImage, template: &GrayImage) -> Image<Luma<f32
             for dy in 0..template_height {
                 for dx in 0..template_width {
                     let image_value = image.get_pixel(x + dx, y + dy)[0] as f32;
-                    let template_value = image.get_pixel(dx, dy)[0] as f32;
+                    let template_value = template.get_pixel(dx, dy)[0] as f32;
+
                     sse += (image_value - template_value).powf(2.0);
                 }
             }
@@ -42,9 +43,44 @@ pub fn match_template(image: &GrayImage, template: &GrayImage) -> Image<Luma<f32
 
 #[cfg(test)]
 mod tests {
+    use image::GrayImage;
     use super::*;
 
-    // TODO test panic for invalid dimensions. test does not panic on boundary condition
-    // TODO test result dimensions
-    // TODO test actual results
+    #[test]
+    #[should_panic]
+    fn match_template_panics_if_image_width_does_not_exceed_template_width() {
+        let _ = match_template(&GrayImage::new(5, 5), &GrayImage::new(5, 4));
+    }
+
+    #[test]
+    #[should_panic]
+    fn match_template_panics_if_image_height_does_not_exceed_template_height() {
+        let _ = match_template(&GrayImage::new(5, 5), &GrayImage::new(4, 5));
+    }
+
+    #[test]
+    fn match_template_accepts_valid_template_size() {
+        let _ = match_template(&GrayImage::new(5, 5), &GrayImage::new(4, 4));
+    }
+
+    #[test]
+    fn match_template_example() {
+        let image = gray_image!(
+            1, 4, 2;
+            2, 1, 3;
+            3, 3, 4
+        );
+        let template = gray_image!(
+            1, 2;
+            3, 4
+        );
+
+        let actual = match_template(&image, &template);
+        let expected = gray_image!(type: f32,
+            14.0, 14.0;
+            3.0, 1.0
+        );
+
+        assert_pixels_eq!(actual, expected);
+    }
 }

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -1,8 +1,8 @@
 //! Functions for performing template matching.
 use definitions::Image;
-use image::{GrayImage, Luma};
+use image::{GenericImage, GrayImage, Luma};
 
-/// Slides a `template` over an image and computes the sum of squared pixel intensity
+/// Slides a `template` over an `image` and computes the sum of squared pixel intensity
 /// differences at each point.
 ///
 /// The returned image has dimensions `image.width() - template.width() + 1` by
@@ -19,7 +19,7 @@ pub fn match_template(image: &GrayImage, template: &GrayImage) -> Image<Luma<f32
     assert!(image_width > template_width, "image width must strictly exceed template width");
     assert!(image_height > template_height, "image height must strictly exceed template height");
 
-    let mut result = Image::<Luma<f32>>::new(image_width - template_width + 1, image_height - template_height + 1);
+    let mut result = Image::new(image_width - template_width + 1, image_height - template_height + 1);
 
     for y in 0..result.height() {
         for x in 0..result.width() {
@@ -27,9 +27,8 @@ pub fn match_template(image: &GrayImage, template: &GrayImage) -> Image<Luma<f32
 
             for dy in 0..template_height {
                 for dx in 0..template_width {
-                    let image_value = image.get_pixel(x + dx, y + dy)[0] as f32;
-                    let template_value = template.get_pixel(dx, dy)[0] as f32;
-
+                    let image_value = unsafe { image.unsafe_get_pixel(x + dx, y + dy)[0] as f32 };
+                    let template_value = unsafe { template.unsafe_get_pixel(dx, dy)[0] as f32 };
                     sse += (image_value - template_value).powf(2.0);
                 }
             }

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -1,1 +1,50 @@
 //! Functions for performing template matching.
+use definitions::Image;
+use image::{GrayImage, Luma};
+
+/// Slides a `template` over an image and computes the sum of squared pixel intensity
+/// differences at each point.
+///
+/// The returned image has dimensions `image.width() - template.width() + 1` by
+/// `image.height() - template.height() + 1`.
+///
+/// # Panics
+///
+/// If either dimension of `template` is not strictly less than the corresponding dimension
+/// of `image`.
+pub fn match_template(image: &GrayImage, template: &GrayImage) -> Image<Luma<f32>> {
+    let (image_width, image_height) = image.dimensions();
+    let (template_width, template_height) = template.dimensions();
+
+    assert!(image_width > template_width, "image width must strictly exceed template width");
+    assert!(image_height > template_height, "image height must strictly exceed template height");
+
+    let mut result = Image::<Luma<f32>>::new(image_width - template_width + 1, image_height - template_height + 1);
+
+    for y in 0..result.height() {
+        for x in 0..result.width() {
+            let mut sse = 0f32;
+
+            for dy in 0..template_height {
+                for dx in 0..template_width {
+                    let image_value = image.get_pixel(x + dx, y + dy)[0] as f32;
+                    let template_value = image.get_pixel(dx, dy)[0] as f32;
+                    sse += (image_value - template_value).powf(2.0);
+                }
+            }
+
+            result.put_pixel(x, y, Luma([sse]));
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TODO test panic for invalid dimensions. test does not panic on boundary condition
+    // TODO test result dimensions
+    // TODO test actual results
+}

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -43,8 +43,10 @@ pub fn match_template(image: &GrayImage, template: &GrayImage) -> Image<Luma<f32
 
 #[cfg(test)]
 mod tests {
-    use image::GrayImage;
     use super::*;
+    use utils::gray_bench_image;
+    use image::GrayImage;
+    use test::{Bencher, black_box};
 
     #[test]
     #[should_panic]
@@ -83,4 +85,22 @@ mod tests {
 
         assert_pixels_eq!(actual, expected);
     }
+
+    macro_rules! bench_match_template {
+        ($name:ident, image_size: $s:expr, template_size: $t:expr) => {
+            #[bench]
+            fn $name(b: &mut Bencher) {
+                let image = gray_bench_image($s, $s);
+                let template = gray_bench_image($t, $t);
+                b.iter(|| {
+                    let result = match_template(&image, &template);
+                    black_box(result);
+                })
+            }
+        }
+    }
+
+    bench_match_template!(bench_match_template_s100_t1, image_size: 100, template_size: 1);
+    bench_match_template!(bench_match_template_s100_t4, image_size: 100, template_size: 4);
+    bench_match_template!(bench_match_template_s100_t16, image_size: 100, template_size: 16);
 }

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -1,0 +1,1 @@
+//! Functions for performing template matching.


### PR DESCRIPTION
Only support GrayImage for now, and only provides sum-of-squared-errors matching.