### PR TITLE
inline several fn

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -147,6 +147,7 @@ impl<'a, K: Num + Copy + 'a> Kernel<'a, K> {
     }
 }
 
+#[inline]
 fn gaussian(x: f32, r: f32) -> f32 {
     ((2.0 * f32::consts::PI).sqrt() * r).recip() * (-x.powi(2) / (2.0 * r.powi(2))).exp()
 }

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -190,6 +190,7 @@ where
     out
 }
 
+#[inline]
 fn gradient_magnitude(dx: f32, dy: f32) -> u16 {
     (dx.powi(2) + dy.powi(2)).sqrt() as u16
 }


### PR DESCRIPTION
I don't know if it was intentional or not but a lot of very simple fn were not inlined.

This speeds up the benchs:

```
$ cargo benchcmp old new
 name                                                                      old ns/iter  new ns/iter  diff ns/iter   diff %  speedup 
 affine::test::bench_affine_bilinear                                       1,060,086    1,049,122         -10,964   -1.03%   x 1.01 
 affine::test::bench_affine_nearest                                        385,276      390,808             5,532    1.44%   x 0.99 
 affine::test::bench_rotate_bilinear                                       539,853      516,242           -23,611   -4.37%   x 1.05 
 affine::test::bench_rotate_nearest                                        403,994      411,252             7,258    1.80%   x 0.98 
 affine::test::bench_translate                                             355,762      348,238            -7,524   -2.11%   x 1.02 
 contrast::test::bench_adaptive_threshold                                  481,960      492,839            10,879    2.26%   x 0.98 
 contrast::test::bench_equalize_histogram                                  820,474      825,476             5,002    0.61%   x 0.99 
 contrast::test::bench_equalize_histogram_mut                              797,083      793,388            -3,695   -0.46%   x 1.00 
 contrast::test::bench_match_histogram                                     146,760      143,791            -2,969   -2.02%   x 1.02 
 contrast::test::bench_match_histogram_mut                                 190,618      186,186            -4,432   -2.33%   x 1.02 
 contrast::test::bench_otsu_level                                          29,091       26,919             -2,172   -7.47%   x 1.08 
 contrast::test::bench_stretch_contrast                                    308,122      277,967           -30,155   -9.79%   x 1.11 
 contrast::test::bench_stretch_contrast_mut                                262,289      253,075            -9,214   -3.51%   x 1.04 
 contrast::test::bench_threshold                                           34,478       32,217             -2,261   -6.56%   x 1.07 
 contrast::test::bench_threshold_mut                                       12,970       12,611               -359   -2.77%   x 1.03 
 corners::test::bench_is_corner_fast12_12_noncontiguous                    31           31                      0    0.00%   x 1.00 
 corners::test::bench_is_corner_fast9_9_contiguous_lighter_pixels          26           27                      1    3.85%   x 0.96 
 distance_transform::test::bench_distance_transform_l1_10                  394          442                    48   12.18%   x 0.89 
 distance_transform::test::bench_distance_transform_l1_100                 32,025       33,103              1,078    3.37%   x 0.97 
 distance_transform::test::bench_distance_transform_l1_200                 126,177      122,459            -3,718   -2.95%   x 1.03 
 distance_transform::test::bench_distance_transform_linf_10                531          575                    44    8.29%   x 0.92 
 distance_transform::test::bench_distance_transform_linf_100               43,760       45,947              2,187    5.00%   x 0.95 
 distance_transform::test::bench_distance_transform_linf_200               181,810      180,838              -972   -0.53%   x 1.01 
 distance_transform::test::bench_euclidean_squared_distance_transform_10   2,329        2,256                 -73   -3.13%   x 1.03 
 distance_transform::test::bench_euclidean_squared_distance_transform_100  221,064      209,920           -11,144   -5.04%   x 1.05 
 distance_transform::test::bench_euclidean_squared_distance_transform_200  1,024,099    879,749          -144,350  -14.10%   x 1.16 
 drawing::bezier::test::bench_draw_cubic_bezier_curve_long                 8,691        8,777                  86    0.99%   x 0.99 
 drawing::bezier::test::bench_draw_cubic_bezier_curve_short                418          377                   -41   -9.81%   x 1.11 
 drawing::conics::test::bench_bench_filled_ellipse_circle                  51,125       44,916             -6,209  -12.14%   x 1.14 
 drawing::conics::test::bench_bench_filled_ellipse_horizontal              58,417       47,377            -11,040  -18.90%   x 1.23 
 drawing::conics::test::bench_bench_filled_ellipse_vertical                30,618       28,019             -2,599   -8.49%   x 1.09 
 drawing::conics::test::bench_bench_hollow_ellipse_circle                  894          793                  -101  -11.30%   x 1.13 
 drawing::conics::test::bench_bench_hollow_ellipse_horizontal              1,215        1,244                  29    2.39%   x 0.98 
 drawing::conics::test::bench_bench_hollow_ellipse_vertical                1,342        1,311                 -31   -2.31%   x 1.02 
 drawing::line::test::bench_draw_antialiased_line_segment_diagonal         4,692        4,226                -466   -9.93%   x 1.11 
 drawing::line::test::bench_draw_antialiased_line_segment_horizontal       4,616        4,287                -329   -7.13%   x 1.08 
 drawing::line::test::bench_draw_antialiased_line_segment_shallow          4,959        4,581                -378   -7.62%   x 1.08 
 drawing::line::test::bench_draw_antialiased_line_segment_vertical         4,011        3,645                -366   -9.12%   x 1.10 
 drawing::rect::test::bench_draw_filled_rect_mut_rgb                       6,869        6,414                -455   -6.62%   x 1.07 
 edges::test::bench_canny                                                  5,391,393    4,956,584        -434,809   -8.06%   x 1.09 
 filter::median::test::bench_median_filter_s100_r1                         190,236      173,910           -16,326   -8.58%   x 1.09 
 filter::median::test::bench_median_filter_s100_r4                         424,805      321,859          -102,946  -24.23%   x 1.32 
 filter::median::test::bench_median_filter_s100_r8                         534,731      481,710           -53,021   -9.92%   x 1.11 
 filter::test::bench_box_filter                                            3,601,140    3,289,749        -311,391   -8.65%   x 1.09 
 filter::test::bench_filter3x3_i32_filter                                  3,003,927    2,671,652        -332,275  -11.06%   x 1.12 
 filter::test::bench_gaussian_f32_stdev_1                                  566,120      472,646           -93,474  -16.51%   x 1.20 
 filter::test::bench_gaussian_f32_stdev_10                                 3,573,414    3,539,462         -33,952   -0.95%   x 1.01 
 filter::test::bench_gaussian_f32_stdev_3                                  1,135,811    1,106,210         -29,601   -2.61%   x 1.03 
 filter::test::bench_horizontal_filter                                     3,195,697    3,296,411         100,714    3.15%   x 0.97 
 filter::test::bench_separable_filter                                      2,351,096    2,306,206         -44,890   -1.91%   x 1.02 
 filter::test::bench_vertical_filter                                       3,163,233    3,181,572          18,339    0.58%   x 0.99 
 gradients::test::bench_sobel_gradients                                    5,635,648    5,758,177         122,529    2.17%   x 0.98 
 haar::test::bench_evaluate_all_features_10x10                             88,541       86,104             -2,437   -2.75%   x 1.03 
 hog::test::bench_hog                                                      787,388      778,400            -8,988   -1.14%   x 1.01 
 hough::test::bench_detect_lines                                           8,603,345    8,729,713         126,368    1.47%   x 0.99 
 integral_image::test::bench_column_running_sum                            1,123        1,106                 -17   -1.51%   x 1.02 
 integral_image::test::bench_integral_image_gray                           806,338      816,345            10,007    1.24%   x 0.99 
 integral_image::test::bench_integral_image_rgb                            2,243,331    2,202,042         -41,289   -1.84%   x 1.02 
 integral_image::test::bench_row_running_sum                               736          707                   -29   -3.94%   x 1.04 
 local_binary_patterns::test::bench_local_binary_pattern                   4,026        4,053                  27    0.67%   x 0.99 
 morphology::test::bench_dilate_l1_5                                       1,233,154    1,263,939          30,785    2.50%   x 0.98 
 morphology::test::bench_dilate_linf_5                                     1,954,790    1,950,987          -3,803   -0.19%   x 1.00 
 noise::test::bench_gaussian_noise_mut                                     186,482      184,793            -1,689   -0.91%   x 1.01 
 noise::test::bench_salt_and_pepper_noise_mut                              139,768      137,707            -2,061   -1.47%   x 1.01 
 pixelops::test::bench_interpolate_gray                                    3            3                       0    0.00%   x 1.00 
 pixelops::test::bench_interpolate_rgb                                     9            10                      1   11.11%   x 0.90 
 pixelops::test::bench_weighted_sum_gray                                   3            3                       0    0.00%   x 1.00 
 pixelops::test::bench_weighted_sum_rgb                                    9            9                       0    0.00%   x 1.00 
 region_labelling::test::bench_connected_components_eight_chessboard       1,880,388    1,869,256         -11,132   -0.59%   x 1.01 
 region_labelling::test::bench_connected_components_four_chessboard        1,131,488    1,220,058          88,570    7.83%   x 0.93 
 seam_carving::test::bench_shrink_width_s100_r1                            262,258      273,173            10,915    4.16%   x 0.96 
 seam_carving::test::bench_shrink_width_s100_r4                            1,045,460    1,059,303          13,843    1.32%   x 0.99 
 seam_carving::test::bench_shrink_width_s100_r8                            2,053,433    2,062,387           8,954    0.44%   x 1.00 
 stats::test::bench_root_mean_squared_error_gray                           9,300        9,365                  65    0.70%   x 0.99 
 stats::test::bench_root_mean_squared_error_rgb                            21,048       21,849                801    3.81%   x 0.96 
 suppress::test::bench_local_maxima_dense                                  38,865       37,484             -1,381   -3.55%   x 1.04 
 suppress::test::bench_local_maxima_sparse                                 52,855       45,420             -7,435  -14.07%   x 1.16 
 suppress::test::bench_suppress_non_maximum_decreasing_gradient            1,156        1,226                  70    6.06%   x 0.94 
 suppress::test::bench_suppress_non_maximum_increasing_gradient            1,870        1,642                -228  -12.19%   x 1.14 
 suppress::test::bench_suppress_non_maximum_noise_1                        5,249        5,174                 -75   -1.43%   x 1.01 
 suppress::test::bench_suppress_non_maximum_noise_3                        3,462        3,130                -332   -9.59%   x 1.11 
 suppress::test::bench_suppress_non_maximum_noise_7                        2,649        2,389                -260   -9.82%   x 1.11 
 template_matching::tests::bench_match_template_s100_t16_sse               3,617,652    3,222,230        -395,422  -10.93%   x 1.12 
 template_matching::tests::bench_match_template_s100_t16_sse_norm          3,338,147    3,194,789        -143,358   -4.29%   x 1.04 
 template_matching::tests::bench_match_template_s100_t1_sse                58,295       51,316             -6,979  -11.97%   x 1.14 
 template_matching::tests::bench_match_template_s100_t1_sse_norm           57,999       53,262             -4,737   -8.17%   x 1.09 
 template_matching::tests::bench_match_template_s100_t4_sse                350,150      313,151           -36,999  -10.57%   x 1.12 
 template_matching::tests::bench_match_template_s100_t4_sse_norm           320,823      309,388           -11,435   -3.56%   x 1.04 
 union_find::test::bench_disjoint_set_forest                               376,851      380,842             3,991    1.06%   x 0.99
```