### PR TITLE
Update rusttype to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ itertools = "0.7.0"
 num = "0.2.0"
 quickcheck = "0.6"
 rand = "0.4.0"
-rusttype = "0.5"
+rusttype = "0.7"
 rayon = "1.0"
 
 [profile.release]


### PR DESCRIPTION
While it might be technically a breaking change, `Font` and `PositionedGlyph` itself retain the same interface, so I think it should be ok to update it as there were numerous changes already

The only breaking change was `CacheBuilder` which is not used by imageproc, at least directly