### PR TITLE
Make quickcheck and assert_approx_eq dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/PistonDevelopers/imageproc"
 exclude = ["examples/*.ttf"]
 
 [dependencies]
-assert_approx_eq = "1.0.0"
 conv = "0.3.1"
 image = "0.20.0"
 itertools = "0.7.0"
@@ -20,6 +19,7 @@ rusttype = "0.7"
 rayon = "1.0"
 
 [dev-dependencies]
+assert_approx_eq = "1.0.0"
 quickcheck = "0.6"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ readme = "README.md"
 homepage = "https://github.com/PistonDevelopers/imageproc"
 exclude = ["examples/*.ttf"]
 
+
+[features]
+default = []
+property-testing = [ "quickcheck" ]
+
 [dependencies]
 conv = "0.3.1"
 image = "0.20.0"
@@ -17,6 +22,7 @@ num = "0.2.0"
 rand = "0.4.0"
 rusttype = "0.7"
 rayon = "1.0"
+quickcheck = { version = "0.6", optional = true }
 
 [dev-dependencies]
 assert_approx_eq = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,12 @@ conv = "0.3.1"
 image = "0.20.0"
 itertools = "0.7.0"
 num = "0.2.0"
-quickcheck = "0.6"
 rand = "0.4.0"
 rusttype = "0.7"
 rayon = "1.0"
+
+[dev-dependencies]
+quickcheck = "0.6"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 homepage = "https://github.com/PistonDevelopers/imageproc"
 exclude = ["examples/*.ttf"]
 
-
 [features]
 default = []
 property-testing = [ "quickcheck" ]
@@ -27,6 +26,9 @@ quickcheck = { version = "0.6", optional = true }
 [dev-dependencies]
 assert_approx_eq = "1.0.0"
 quickcheck = "0.6"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [profile.release]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod math;
 pub mod morphology;
 pub mod noise;
 pub mod pixelops;
+#[cfg(test)]
 pub mod property_testing;
 pub mod rect;
 pub mod region_labelling;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub mod math;
 pub mod morphology;
 pub mod noise;
 pub mod pixelops;
-#[cfg(test)]
+#[cfg(any(feature = "property-testing", test))]
 pub mod property_testing;
 pub mod rect;
 pub mod region_labelling;


### PR DESCRIPTION
Saves any dependants a little compile time, as those crates are only used for testing as far as I can see.