### PR TITLE
Fix cargo test, remove some duplication in display_window function

### DIFF
--- a/examples/display_image.rs
+++ b/examples/display_image.rs
@@ -1,19 +1,30 @@
-use imageproc::window::display_image;
-use std::env;
+//! An example of displaying an image in a window using the display_image function.
+//! Run this example from your root directory, enabled the display_image feature and
+//! provide a path to an image file as an argument.
+//!
+//! `cargo run --release --features display-window --example display_image examples/wrench.jpg`
 
-// run this example from your root directory, use the "--features" flag and
-// provide a path to an image file as an argument
-// "cargo run --release --features "display-window" --example display_image examples/wrench.jpg" from your root directory
+#[cfg(feature = "display-window")]
 fn main() {
-    let img_path = match env::args().nth(1) {
+    use imageproc::window::display_image;
+    use std::env;
+
+    let image_path = match env::args().nth(1) {
         Some(path) => path,
         None => {
             println!("No image path provided. Using default image.");
             "examples/wrench.jpg".to_owned()
         }
     };
-    let img = image::open(&img_path)
-        .expect("no image found at that path")
+
+    let image = image::open(&image_path)
+        .expect("No image found at provided path")
         .to_rgba();
-    display_image("", &img, 10, 10);
+
+    display_image("", &image, 10, 10);
+}
+
+#[cfg(not(feature = "display-window"))]
+fn main() {
+    panic!("Displaying images is only supported if the display-window feature is enabled.");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,5 +46,5 @@ pub mod stats;
 pub mod suppress;
 pub mod template_matching;
 pub mod union_find;
-#[cfg(feature="display-window")]
+#[cfg(feature = "display-window")]
 pub mod window;

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,113 +1,77 @@
 //! Displays an image in a window created by sdl2.
 
-use image::RgbaImage;
-use sdl2::event::{Event, WindowEvent};
-use sdl2::keyboard::Keycode;
-use sdl2::pixels::{Color, PixelFormatEnum};
-use sdl2::rect::Rect;
-use sdl2::surface::Surface;
+use image::{RgbaImage, imageops::resize};
+use sdl2::{
+    event::{Event, WindowEvent},
+    keyboard::Keycode,
+    pixels::{Color, PixelFormatEnum},
+    rect::Rect,
+    surface::Surface
+};
 
 /// Displays the provided RGBA image in a new window.
-/// Minimum window size is 150 x 150.
+///
+/// The minimum window width or height is 150 pixels - input values less than this
+/// will be rounded up to the minimum.
 pub fn display_image(title: &str, image: &RgbaImage, window_width: u32, window_height: u32) {
+    // Enforce minimum window size
     const MIN_WINDOW_DIMENSION: u32 = 150;
-    // ensures window size is minimum size, so that image resizing calculations for the window are correct
-    let window_width: u32 = if window_width < MIN_WINDOW_DIMENSION {
-        MIN_WINDOW_DIMENSION
-    } else {
-        window_width
-    };
-    let window_height: u32 = if window_height < MIN_WINDOW_DIMENSION {
-        MIN_WINDOW_DIMENSION
-    } else {
-        window_height
-    };
+    let window_width = window_width.max(MIN_WINDOW_DIMENSION);
+    let window_height = window_height.max(MIN_WINDOW_DIMENSION);
 
-    // resizes and returns the image that will be used to display in the window
-    fn create_display_image(
-        image: &RgbaImage,
-        window_width: u32,
-        window_height: u32,
-    ) -> (u32, u32, RgbaImage) {
-        if image.height() < window_height && image.width() < window_width {
-            (image.width(), image.height(), image.clone())
-        } else {
-            // scale is used to determine how small an image has to be resized to fit within
-            // the provided window dimensions
-            let scale = {
-                let width_scale = window_width as f32 / image.width() as f32;
-                let height_scale = window_height as f32 / image.height() as f32;
-                if width_scale < height_scale {
-                    width_scale
-                } else {
-                    height_scale
-                }
-            };
-            let height = (scale * image.height() as f32) as u32;
-            let width = (scale * image.width() as f32) as u32;
-            let output_image =
-                image::imageops::resize(image, width, height, image::FilterType::Triangle);
-            (width, height, output_image)
-        }
-    }
-
-    let (output_image_width, output_image_height, output_image) =
-        create_display_image(image, window_width, window_height);
-
-    const CHANNEL_COUNT: u32 = 4;
-    let pitch = output_image_width * CHANNEL_COUNT;
-    let mut img_raw = output_image.into_raw();
-    let surface_img = Surface::from_data(
-        &mut img_raw,
-        output_image_width,
-        output_image_height,
-        pitch,
-        PixelFormatEnum::ABGR8888, // this format is necessary because sdl2 expects bits from highest to lowest
-    )
-    .expect("couldn't converted image to surface");
-
+    // Initialise sdl2 window
     let sdl = sdl2::init().expect("couldn't create sdl2 context");
     let video_subsystem = sdl.video().expect("couldn't create video subsystem");
+
     let mut window = video_subsystem
         .window(title, window_width, window_height)
         .position_centered()
         .resizable()
         .build()
-        .expect("window couldn't be created");
+        .expect("couldn't create window");
+
     window
         .set_minimum_size(MIN_WINDOW_DIMENSION, MIN_WINDOW_DIMENSION)
         .expect("invalid minimum size for window");
 
-    let mut canvas = window
-        .into_canvas()
+    let mut canvas = window.into_canvas()
         .build()
-        .expect("Couldn't create CanvasBuilder");
+        .expect("couldn't create canvas");
+
     let texture_creator = canvas.texture_creator();
 
-    let mut texture = texture_creator
-        .create_texture_from_surface(surface_img)
-        .expect("couldn't create texture from surface");
+    // Shrinks input image to fit if required and renders to the sdl canvas
+    let mut render_image_to_canvas = |image, window_width, window_height| {
+        let scaled_image = resize_to_fit(image, window_width, window_height);
+        let (image_width, image_height) = scaled_image.dimensions();
 
-    // calculates new location for surface from window origin so that
-    // the image is centered in the window
-    let center_x = ((window_width - output_image_width) as f32 / 2.0_f32) as i32;
-    let center_y = ((window_height - output_image_height) as f32 / 2.0_f32) as i32;
+        let mut buffer = scaled_image.into_raw();
+        const CHANNEL_COUNT: u32 = 4;
 
-    // makes background white
-    canvas.set_draw_color(Color::RGB(255, 255, 255));
-    canvas.clear();
+        let surface = Surface::from_data(
+            &mut buffer,
+            image_width,
+            image_height,
+            image_width * CHANNEL_COUNT,
+            PixelFormatEnum::ABGR8888 // sdl2 expects bits from highest to lowest
+        ).expect("couldn't create surface");
 
-    // displays image in the window
-    canvas
-        .copy(
-            &texture,
-            None,
-            Rect::new(center_x, center_y, output_image_width, output_image_height),
-        )
-        .unwrap();
-    canvas.present();
+        let texture = texture_creator
+            .create_texture_from_surface(surface)
+            .expect("couldn't create texture from surface");
 
-    // create and start events loop to keep window open until Esc
+        canvas.set_draw_color(Color::RGB(255, 255, 255));
+        canvas.clear();
+
+        let left = ((window_width - image_width) as f32 / 2f32) as i32;
+        let top = ((window_height - image_height) as f32 / 2f32) as i32;
+        canvas.copy(&texture, None, Rect::new(left, top, image_width, image_height)).unwrap();
+        canvas.present();
+    };
+
+    render_image_to_canvas(image, window_width, window_height);
+
+    // Create and start event loop to keep window open until Esc
     let mut event_pump = sdl.event_pump().unwrap();
     event_pump.enable_event(sdl2::event::EventType::Window);
     'running: loop {
@@ -119,44 +83,31 @@ pub fn display_image(title: &str, image: &RgbaImage, window_width: u32, window_h
                     ..
                 } => break 'running,
                 Event::Window {
-                    win_event: WindowEvent::Resized(x, y),
+                    win_event: WindowEvent::Resized(w, h),
                     ..
                 } => {
-                    let x = x as u32;
-                    let y = y as u32;
-                    // resize image if necessary to fit into the window
-                    let (output_image_width, output_image_height, output_image) =
-                        create_display_image(image, x, y);
-
-                    let pitch = output_image_width * CHANNEL_COUNT;
-                    let mut img_raw = output_image.into_raw();
-                    let surface_img = Surface::from_data(
-                        &mut img_raw,
-                        output_image_width,
-                        output_image_height,
-                        pitch,
-                        PixelFormatEnum::ABGR8888, // this format is necessary because sdl2 expects bits from highest to lowest
-                    )
-                    .expect("couldn't convert image to surface");
-
-                    texture = texture_creator
-                        .create_texture_from_surface(surface_img)
-                        .expect("couldn't create texture from surface");
-
-                    let center_x = ((x - output_image_width) as f32 / 2.0_f32) as i32;
-                    let center_y = ((y - output_image_height) as f32 / 2.0_f32) as i32;
-                    canvas.clear();
-                    canvas
-                        .copy(
-                            &texture,
-                            None,
-                            Rect::new(center_x, center_y, output_image_width, output_image_height),
-                        )
-                        .unwrap();
-                    canvas.present();
+                    render_image_to_canvas(image, w as u32, h as u32);
                 }
                 _ => {}
             }
         }
     }
+}
+
+// Scale input image down if required so that it fits within a window of the given dimensions
+fn resize_to_fit(image: &RgbaImage, window_width: u32, window_height: u32) -> RgbaImage {
+    if image.height() < window_height && image.width() < window_width {
+        return image.clone();
+    }
+
+    let scale = {
+        let width_scale = window_width as f32 / image.width() as f32;
+        let height_scale = window_height as f32 / image.height() as f32;
+        width_scale.min(height_scale)
+    };
+
+    let height = (scale * image.height() as f32) as u32;
+    let width = (scale * image.width() as f32) as u32;
+
+    resize(image, width, height, image::FilterType::Triangle)
 }


### PR DESCRIPTION
cc @lazypassion 

The change to the display_image example was required for "cargo test" to succeed (as it tries to build all of the examples, which previously didn't work without the display-window feature).

The changes to display_window itself are mainly just pulling out a render_image_to_canvas function to remove a bit of code duplication.